### PR TITLE
[design] 강의링크버튼, 토스트 알림창 공통 컴포넌트 생성

### DIFF
--- a/src/components/common/CourseLink.tsx
+++ b/src/components/common/CourseLink.tsx
@@ -1,0 +1,28 @@
+import Link from 'next/link';
+
+type TCourseLinkProps = {
+  courseTitle: string;
+  courseLink?: string;
+};
+
+export default function CourseLink(props: TCourseLinkProps) {
+  const { courseTitle, courseLink = '/' } = props;
+  return (
+    <>
+      <div className="flex items-center justify-between bg-main-color text-white rounded-[0.5rem] w-full h-[4.2rem] px-[1.2rem] py-[1.0rem] box-border gap-[0.8rem]">
+        <span className="flex-shrink-0 px-[0.6rem] py-[0.2rem] bg-main-200 text-[1.2rem] text-main-color font-medium rounded-[0.3rem] box-border">
+          강의
+        </span>
+        <span className="flex-grow text-text-caption text-gray-300 w-[22.7rem] font-medium truncate">
+          {courseTitle}
+        </span>
+        <Link
+          href={courseLink}
+          className="flex-shrink-0 text-[1.2rem] underline text-gray-400"
+        >
+          바로가기
+        </Link>
+      </div>
+    </>
+  );
+}

--- a/src/components/common/Toast.tsx
+++ b/src/components/common/Toast.tsx
@@ -1,0 +1,15 @@
+type TToastProps = {
+  message: string;
+};
+
+export default function Toast(props: TToastProps) {
+  const { message } = props;
+
+  return (
+    <>
+      <div className="fixed top-10 left-1/2 transform -translate-x-1/2 bg-[#555] bg-opacity-95 w-[90%] text-center px-[2rem] py-[1rem] rounded-[0.8rem] text-white">
+        <span className="text-text-caption font-medium">{message}</span>
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
### 🖼️ Screen shot

| 완성 이미지/GIF |

| CourseLink.tsx | Toast.tsx |
| :-------------: | :-------------: |
| <img width="354" alt="스크린샷 2024-06-25 오전 10 05 42" src="https://github.com/Woongjin-Udemy-Pixe11/sturing/assets/139545377/aae71209-deab-45b8-8e09-548117746f9f">  | <img width="355" alt="스크린샷 2024-06-25 오전 10 06 27" src="https://github.com/Woongjin-Udemy-Pixe11/sturing/assets/139545377/4c307b5a-8ce1-4870-aadc-1389e8e40754">  |


### 📝 Details

- `CourseLink ` 컴포넌트에서 `courseTitle `에는 강의제목에 들어갈 내용, `courseLink `에는 강의링크를 넣으면 됩니다. (default ='/')
- `Toast `에서 `message `은 들어갈 내용을 넣으면 됩니다. 
 
```tsx
<CourseLink courseTitle="UXUI 디자이너가 피그마를 활용해 포트폴리오를 쌓는 법 A to Z" courseLink="/" />
<Toast message="클립보드가 복사되었습니다." />
```



