### PR TITLE
[design] 헤더 컴포넌트 생성

### DIFF
--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -1,0 +1,34 @@
+import { IoMenu } from 'react-icons/io5';
+import { IoPersonOutline } from 'react-icons/io5';
+import { GoBell } from 'react-icons/go';
+
+export default function Header() {
+  return (
+    <>
+      <header className=" w-full h-[5.4rem] flex justify-between items-center px-[0.8rem] text-gray-1000">
+        <div className=" w-[50%] flex justify-start items-center gap-[0.8rem]">
+          <button>
+            <IoMenu className="w-[2.4rem] h-[2.4rem]" />
+          </button>
+          <h1 className="w-[7.8rem] h-[2.4rem] cursor-pointer">
+            <figure>
+              <img src="/logo.svg" alt="스터링 로고" className="w-full" />
+              <figcaption className="sr-only">
+                영어로 "sturing"이 쓰여있고, 글씨는 검정색입니다. 그리스 문자
+                감마와 비슷하게 생긴 "r"과 "i"의 타이틀은 파란색입니다.
+              </figcaption>
+            </figure>
+          </h1>
+        </div>
+        <div className="w-[50%] flex justify-end items-center gap-[1.2rem]">
+          <button>
+            <GoBell className="w-[2.4rem] h-[2.4rem]" />
+          </button>
+          <button>
+            <IoPersonOutline className="w-[2.4rem] h-[2.4rem]" />
+          </button>
+        </div>
+      </header>
+    </>
+  );
+}


### PR DESCRIPTION
### 🖼️ Screen shot

| 완성 이미지/GIF |
| :-------------: |
| <img src='https://github.com/Woongjin-Udemy-Pixe11/sturing/assets/91606951/97edb88a-24b2-49ea-9d0f-641a866dbd10' />  |

### 📝 Details

- 퍼블리싱만 완료 했습니다.
- 햄버거 메뉴 클릭 시 사이드바가 열려야 합니다.
- 알림 클릭 시 드롭다운 박스가 나와야 합니다.
- 유저 클릭 시 마이페이지로 이동해야 합니다.

