### PR TITLE
[design] 마이페이지 퍼블리싱 완료

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -12,7 +12,9 @@ export default function RootLayout({
 }) {
   return (
     <html lang="ko">
-      <body className="w-[375px] m-auto">{children}</body>
+      <body>{children}</body>
     </html>
   );
 }
+
+//TODO: body 에 className="w-[375px] m-auto" 스타일 추가하기

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -12,9 +12,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="ko">
-      <body>{children}</body>
+      <body className="w-[375px] m-auto">{children}</body>
     </html>
   );
 }
-
-//TODO: body 에 className="w-[375px] m-auto" 스타일 추가하기

--- a/src/app/matching/_components/ClientMatching.tsx
+++ b/src/app/matching/_components/ClientMatching.tsx
@@ -33,7 +33,7 @@ export default function ClientMatching() {
     6: <MatchingCompleted />,
   };
   return (
-    <main className="flex flex-col w-full h-[750px] relative ">
+    <main className="flex flex-col w-full  relative mt-[6rem] ">
       <header>
         <GoChevronLeft size={30} className="mb-4" />
 
@@ -46,18 +46,20 @@ export default function ClientMatching() {
           </div>
         )}
       </header>
-      {stepComponet[step]}
-      {step <= 5 && (
-        <MatchingFooter
-          step={step}
-          Forward={() => {
-            onClickForwardStep();
-          }}
-          Backward={() => {
-            onClickBackwardStep();
-          }}
-        />
-      )}
+      <div className="w-full m-auto relative">
+        {stepComponet[step]}
+        {step <= 5 && (
+          <MatchingFooter
+            step={step}
+            Forward={() => {
+              onClickForwardStep();
+            }}
+            Backward={() => {
+              onClickBackwardStep();
+            }}
+          />
+        )}
+      </div>
     </main>
   );
 }

--- a/src/app/matching/_components/Field.tsx
+++ b/src/app/matching/_components/Field.tsx
@@ -14,14 +14,14 @@ export default function Field() {
     );
   });
   return (
-    <div className="w-[37.5rem] px-[1.4rem]">
+    <div className="w-full px-[1.4rem]">
       <section className="py-[2rem] ">
         <h1 className="font-black text-headline-3">관심 분야에 대한</h1>
         <h1 className="font-black text-headline-3">
           나의 직업 수준을 선택해 주세요.
         </h1>
       </section>
-      <section className="mt-[4rem]">
+      <section className="mt-[4rem] w-full">
         <Tabs.Root defaultValue="디자인">
           <Tabs.List className="flex">
             <Tabs.Trigger value="디자인" className="flex-1 minitab-trigger">
@@ -34,15 +34,13 @@ export default function Field() {
               기획,마케팅
             </Tabs.Trigger>
           </Tabs.List>
-          <div className="py-5">
-            <Tabs.Content value="디자인" className="flex flex-col gap-[1.4rem]">
-              {levelComponet}
+          <div className="py-5 ">
+            {/* //TODO: flex 일떄는 중앙정렬되는데, 해제하면 중앙이안됨 why? */}
+            <Tabs.Content value="디자인">
+              <div className="m-auto flex flex-col gap-3">{levelComponet}</div>
             </Tabs.Content>
-            <Tabs.Content
-              value="기획,마케팅"
-              className="flex flex-col gap-[1.4rem]"
-            >
-              {levelComponet}
+            <Tabs.Content value="기획,마케팅">
+              <div className="m-auto flex flex-col gap-3">{levelComponet}</div>
             </Tabs.Content>
           </div>
         </Tabs.Root>

--- a/src/app/matching/_components/Interest.tsx
+++ b/src/app/matching/_components/Interest.tsx
@@ -4,7 +4,7 @@ import FlexContainer from '@/components/(jonghoo)/FlexContainer';
 
 export default function Interest() {
   return (
-    <div className="w-[37.5rem] px-[1.6rem] py-[2rem]">
+    <div className="w-full px-[1.6rem] py-[2rem]">
       <section>
         <h1 className="font-black text-headline-3">웅진님 안녕하세요.</h1>{' '}
         <h1 className="font-black text-headline-3">
@@ -20,7 +20,7 @@ export default function Interest() {
           .map((label) => (
             <SelectMatching key={label.title} type="interest">
               <img src={label.imgSrc} alt={label.imgAlt} />
-              <div className="ml-2">{label.title}</div>
+              <div>{label.title}</div>
             </SelectMatching>
           ))}
       </FlexContainer>

--- a/src/app/matching/_components/MatchingCompleted.tsx
+++ b/src/app/matching/_components/MatchingCompleted.tsx
@@ -50,6 +50,7 @@ export default function MatchingCompleted() {
               .map((card) => (
                 <div key={card.studyName}>
                   <Card
+                    width="182"
                     studyImage={card.studyImage}
                     studyMeetings={card.studyMettings}
                     studyTypeisBlue={card.studyTypeisBlue}

--- a/src/app/matching/_components/MatchingCompleted.tsx
+++ b/src/app/matching/_components/MatchingCompleted.tsx
@@ -69,7 +69,7 @@ export default function MatchingCompleted() {
         </div>
       </section>
       <footer>
-        <div className="w-full absolute bottom-0 px-[1.6rem] py-[1.2rem] flex flex-col gap-[1.2rem]">
+        <div className="w-full absolute bottom-[-10%] px-[1.6rem] py-[1.2rem] flex flex-col gap-[1.2rem]">
           <LongButton color="blue">내 프로필 보러가기</LongButton>
           <LongButton color="gray">홈으로 가기</LongButton>
         </div>

--- a/src/app/matching/_components/Mood.tsx
+++ b/src/app/matching/_components/Mood.tsx
@@ -4,8 +4,8 @@ import { emojiLabelList } from '@/constant/emojiLabelList';
 
 export default function Mood() {
   return (
-    <div className="w-[37.5rem] flex flex-col gap-5">
-      <section className=" px-[1.6rem] py-[2rem]">
+    <div className="w-full px-[1.6rem] py-[2rem]">
+      <section>
         <h1 className="font-black text-headline-3">웅진님이 선호하는</h1>
         <h1 className="font-black text-headline-3">
           스터디 분위기를 선택해 주세요.

--- a/src/app/matching/_components/Region.tsx
+++ b/src/app/matching/_components/Region.tsx
@@ -1,4 +1,3 @@
-import MatchingFooter from '@/components/(jonghoo)/MatchingFooter';
 import CommonTab from '@/components/common/Tab/CommonTab';
 
 export default function Region() {

--- a/src/app/matching/_components/Region.tsx
+++ b/src/app/matching/_components/Region.tsx
@@ -3,7 +3,7 @@ import CommonTab from '@/components/common/Tab/CommonTab';
 
 export default function Region() {
   return (
-    <div className="w-[37.5rem] flex flex-col gap-5">
+    <div className="w-full">
       <section className="pt-[2rem] px-[1.6rem]">
         <h1 className="font-black text-headline-3">웅진님이 선호하는</h1>
         <h1 className="font-black text-headline-3">
@@ -14,7 +14,6 @@ export default function Region() {
         </p>
       </section>
       <CommonTab />
-    
     </div>
   );
 }

--- a/src/app/matching/_components/Type.tsx
+++ b/src/app/matching/_components/Type.tsx
@@ -3,7 +3,7 @@ import { FaCheck } from 'react-icons/fa6';
 
 export default function Type() {
   return (
-    <div className="w-[37.5rem] px-[1.4rem]">
+    <div className="w-full px-[1.4rem]">
       <section className="py-[2rem] ">
         <h1 className="font-black text-headline-3">웅진님이 선호하는</h1>
         <h1 className="font-black text-headline-3">

--- a/src/app/users/[userid]/_componets/AccountCancelModal.tsx
+++ b/src/app/users/[userid]/_componets/AccountCancelModal.tsx
@@ -1,0 +1,39 @@
+import LongButton from '@/components/common/LongButton';
+import MyPageHeader from './MypageHeader';
+
+export default function AccountCancelMoadl() {
+  return (
+    <main>
+      <MyPageHeader>
+        <h1 className="font-bold text-headline-3">회원 탈퇴</h1>
+      </MyPageHeader>
+      <section className="font-bold text-headline-3 pl-[1.6rem] py-[3.1rem]">
+        <h1>정말 탈퇴하시겠어요?</h1>
+        <h1>탈퇴하기 전에 확인해주세요!</h1>
+      </section>
+
+      <ul className="list-disc text-gray-700 pl-[2.6rem]">
+        <li className="px-[0.5rem] py-[1.5rem]">
+          진행중,종료,대기중인 모든 스터디가 사라집니다.
+        </li>
+        <li className="px-[0.5rem] py-[1.5rem]">
+          모든 스터디에서 팀원 OOO님이 사라집니다.
+        </li>
+        <li className="px-[0.5rem] py-[1.5rem]">
+          작성하신 모든 글(게시물,댓글,투두리스트)등이 전부 삭제됩니다.
+        </li>
+        <li className="px-[0.5rem] py-[1.5rem]">
+          모든 이용내역은 삭제되며 복원이 불가능 합니다.
+        </li>
+        <li className="px-[0.5rem] py-[1.5rem]">
+          계정이 삭제되면 복원이 불가능 합니다.
+        </li>
+      </ul>
+      <div className="text-right">
+        <button className="border text-main-600 border-main-600 px-[1.2rem] py-[0.6rem] text-content-2 rounded-[0.5rem] mt-[4rem]  ">
+          회원 탈퇴하기
+        </button>
+      </div>
+    </main>
+  );
+}

--- a/src/app/users/[userid]/_componets/MiniAgreeModal.tsx
+++ b/src/app/users/[userid]/_componets/MiniAgreeModal.tsx
@@ -1,0 +1,15 @@
+export default function MiniAgreeModal() {
+  return (
+    <div className="w-[22rem] h-[14.4rem] px-[5rem] py-[4rem] border boder-black rounded-md">
+      <h1 className="text-[1.2rem]">정말 탈퇴하시겠습니까?</h1>
+      <section className="mt-[1.4rem] w-full flex gap-[0.6rem] ">
+        <button className="border bg-main-600 px-[0.6rem] py-[0.2rem] text-content-2 rounded  text-gray-200 flex-1">
+          예
+        </button>
+        <button className="border border-main-600 px-[0.6rem] py-[0.2rem] text-content-2 rounded  text-main-600 flex-1">
+          아니오
+        </button>
+      </section>
+    </div>
+  );
+}

--- a/src/app/users/[userid]/_componets/MyPageLabel.tsx
+++ b/src/app/users/[userid]/_componets/MyPageLabel.tsx
@@ -1,0 +1,13 @@
+type TMypageLabelProps = {
+  content: string;
+};
+
+export default function MyPageLabel(props: TMypageLabelProps) {
+  const { content } = props;
+  const classList = `bg-main-200 rounded-[0.3rem] py-2 px-4 text-content-2 font-medium`;
+  return (
+    <>
+      <span className={classList}>{content}</span>
+    </>
+  );
+}

--- a/src/app/users/[userid]/_componets/MyPageProfileCard.tsx
+++ b/src/app/users/[userid]/_componets/MyPageProfileCard.tsx
@@ -1,0 +1,23 @@
+import { FaChevronRight } from 'react-icons/fa6';
+import MyPageLabel from './MyPageLabel';
+export default function MyPageProfileCard({ auth }: { auth?: boolean }) {
+  return (
+    <section className="flex border-[0.1rem] border-gray-100 py-[2.4rem] px-[2rem] mt-5 rounded-md  gap-3">
+      <div className="w-[7rem] h-[7rem] border border-gray-500 rounded-full ">
+        <img src="/images/user-card-dummy.png" className="object-fit"></img>
+      </div>
+      <div>
+        <div className="flex gap-4">
+          <h1 className="font-bold text-headline-3">웅진님</h1>
+          {auth && <h2>{'>'}</h2>}
+        </div>
+        <h3 className="text-content-2">비기너</h3>
+        <div className="flex gap-2 mt-2">
+          <MyPageLabel content="🌏 성동구" />
+          <MyPageLabel content="디자인" />
+          <MyPageLabel content="열정적인" />
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/app/users/[userid]/_componets/MyPageProfileCard.tsx
+++ b/src/app/users/[userid]/_componets/MyPageProfileCard.tsx
@@ -2,7 +2,7 @@ import { FaChevronRight } from 'react-icons/fa6';
 import MyPageLabel from './MyPageLabel';
 export default function MyPageProfileCard({ auth }: { auth?: boolean }) {
   return (
-    <section className="flex border-[0.1rem] border-gray-100 py-[2.4rem] px-[2rem] mt-5 rounded-md  gap-3">
+    <section className="flex border-[0.1rem] border-gray-200 py-[2.4rem] px-[2rem] mt-5 rounded-md  gap-3">
       <div className="w-[7rem] h-[7rem] border border-gray-500 rounded-full ">
         <img src="/images/user-card-dummy.png" className="object-fit"></img>
       </div>

--- a/src/app/users/[userid]/_componets/MyStudyInfo.tsx
+++ b/src/app/users/[userid]/_componets/MyStudyInfo.tsx
@@ -1,0 +1,26 @@
+import LongButton from '@/components/common/LongButton';
+
+export default function MyStudyInfo() {
+  return (
+    <>
+      <section className="flex w-full px-[2.4rem] py-[2rem]">
+        <div className="flex-1 text-center border-r-[0.1rem] border-gray-400">
+          <h1>2</h1>
+          <h2>활동 중 스터디</h2>
+        </div>
+        <div className="flex-1 text-center">
+          <h1>4</h1>
+          <h2>종료 중 스터디</h2>
+        </div>
+      </section>
+      <section className="flex gap-2 mt-3">
+        <LongButton color="white">
+          <p className="text-gray-900 text-content-1">내 관심목록</p>
+        </LongButton>
+        <LongButton color="white">
+          <p className="text-gray-900 text-content-1">매칭정보 수정</p>
+        </LongButton>
+      </section>
+    </>
+  );
+}

--- a/src/app/users/[userid]/_componets/MypageHeader.tsx
+++ b/src/app/users/[userid]/_componets/MypageHeader.tsx
@@ -1,0 +1,14 @@
+import { GoChevronLeft } from 'react-icons/go';
+
+export default function MyPageHeader({
+  children,
+}: {
+  children?: React.ReactNode;
+}) {
+  return (
+    <header className="flex text-center  border-b-2 border-gray-300">
+      <GoChevronLeft size={24} className="mb-4" />
+      {children && <h1 className="flex-1">{children}</h1>}
+    </header>
+  );
+}

--- a/src/app/users/[userid]/_componets/StudyReviewCard.tsx
+++ b/src/app/users/[userid]/_componets/StudyReviewCard.tsx
@@ -1,0 +1,16 @@
+export default function StudyReviewCard() {
+  return (
+    <section className="flex gap-[0.8rem]  border-b-2 border-gray-400 pb-[2rem] w-[90%]">
+      <div className="w-[3.5rem] h-[3.5rem] border border-gray-500 rounded-full">
+        <img src="/images/user-card-dummy.png" className="object-fill"></img>
+      </div>
+      <div className="w-[29.7rem] flex flex-col gap-4">
+        <h1 className="font-bold">취뽀기원</h1>
+        <p>
+          같이 스터디해서 좋았습니다~ 책임감이 강하시고 열심히 하시는
+          모습이좋아요
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/src/app/users/[userid]/_componets/SturingRate.tsx
+++ b/src/app/users/[userid]/_componets/SturingRate.tsx
@@ -1,0 +1,27 @@
+export default function SturingRate() {
+  return (
+    <div className="flex flex-col gap-[1.8rem]">
+      <h2 className="px-[1.6rem] mt-[5.6rem] text-headline-3 font-bold">
+        스터링 지수
+      </h2>
+      <section>
+        <article className="border-[0.1rem] border-gray-300 px-[2.4rem] py-[3.9rem] rounded-md">
+          <div className="relative flex items-center justify-center w-[5.6rem] h-[3rem] bg-blue-500 text-white text-2xl rounded-[10rem] mb-2 m-auto left-12">
+            <span>61%</span>
+            <div className="absolute bottom-0 left-1/2 transform -translate-x-1/2 translate-y-1/2 w-2 h-2 bg-blue-500 rotate-45"></div>
+          </div>
+          <div className="w-full bg-gray-400 rounded-full h-[0.8rem] ">
+            <div
+              className="bg-gradient-to-r from-[#FFE4E0] to-[#3A6CFF] h-[0.8rem] rounded-full"
+              style={{ width: '61%' }}
+            ></div>
+          </div>
+          <div className="w-[0.6rem] h-[0.6rem] bg-gray-600 rounded-full m-auto mt-[0.65rem]"></div>
+          <p className="text-content-2 text-center text-gray-600">
+            첫 지수 50%
+          </p>
+        </article>
+      </section>
+    </div>
+  );
+}

--- a/src/app/users/[userid]/_componets/UserDetailInfo.tsx
+++ b/src/app/users/[userid]/_componets/UserDetailInfo.tsx
@@ -1,15 +1,33 @@
+'use client';
+
+import { useState } from 'react';
+
+//TODO: UserLabel 컴포넌트 공통화 할것인지? 안할것인지 정하기
 export default function UserDetailInfo() {
+  const [editMode, setEditMode] = useState<boolean>(false);
+  const onClickEditMode = () => {
+    setEditMode(!editMode);
+  };
   return (
     <main>
-      <h2>기본정보</h2>
-      <div>
-        <div className="flex flex-col">
+      <h2 className="text-headline-3 font-bold mb-[2.4rem]">기본정보</h2>
+      <div className="text-[1.6rem] text-gray-600 flex flex-col gap-[4.6rem]">
+        <div className="flex flex-col gap-3 border-b-2 border-gray-300 pb-[1.2rem]">
           <label>사용자 이름</label>
-          <input type="text" value="홍길동" />
+          <div>홍길동</div>
         </div>
-        <div className="flex flex-col">
+        <div className="flex flex-col gap-3 border-b-2 border-gray-300 pb-[1.2rem]">
           <label>로그인 이메일</label>
-          <input type="text" />
+          <div>kafmjh12@gmail.com</div>
+        </div>
+        <div className="flex flex-col gap-3 border-b-2 border-gray-300 pb-[1.2rem]">
+          <label htmlFor="nick">닉네임</label>
+          <div className="flex justify-between">
+            <div className="text-gray-950">{editMode ? <input /> : '웅진'}</div>
+            <div className="text-main-600" onClick={onClickEditMode}>
+              {editMode ? <button>완료</button> : <button>수정</button>}
+            </div>
+          </div>
         </div>
       </div>
     </main>

--- a/src/app/users/[userid]/_componets/UserMatchingInfo.tsx
+++ b/src/app/users/[userid]/_componets/UserMatchingInfo.tsx
@@ -1,0 +1,38 @@
+//TODO: 글자 | 글자 | 글자 좀더깔끔하게 css design 할수있는 방법있으면 변경할것
+
+export default function UserMatchingInfo() {
+  return (
+    <main className="border-t-4 border-gray-400 mt-[4rem] py-[3.6rem] ">
+      <header className="flex justify-between">
+        <h1 className="font-bold text-headline-3">매칭정보</h1>
+        <button className="text-[1.6rem] text-main-600">수정</button>
+      </header>
+      <section className="text-[1.6rem] text-gray-600 flex flex-col gap-[4.6rem] mt-[2.2rem]">
+        <div className=" border-b-2 border-gray-300 pb-[1.2rem]">
+          <label>관심분야 및 수준</label>
+          <ul className="flex gap-[2rem] text-gray-900 py-[1.2rem] ">
+            <li className="leading-10 relative after:content:none after:w-[0.05rem] after:h-[1.9rem] after:absolute after:top-[50%] after:right-[-1rem] after:translate-y-[-50%] after:bg-slate-300">
+              디자인-비기너
+            </li>
+            <li className="leading-10 relative after:content:none after:w-[0.05rem] after:h-[1.9rem] after:absolute after:top-[50%] after:right-[-1rem] after:translate-y-[-50%] after:bg-slate-300">
+              비즈니스-주니어
+            </li>
+            <li>마케팅-시니어</li>
+          </ul>
+        </div>
+        <div className="flex flex-col gap-3 border-b-2 border-gray-300 pb-[1.2rem]">
+          <label>선호 지역</label>
+          <ul className="flex gap-2 text-gray-900">
+            <li className="leading-10 relative after:content:none after:w-[0.05rem] after:h-[1.9rem] after:absolute after:top-[50%] after:right-[-0.3rem] after:translate-y-[-50%] after:bg-slate-300">
+              서울 성동구
+            </li>
+            <li className="leading-10 relative after:content:none after:w-[0.05rem] after:h-[1.9rem] after:absolute after:top-[50%] after:right-[-0.3rem] after:translate-y-[-50%] after:bg-slate-300">
+              서울 강서구
+            </li>
+            <li>서울 강남구</li>
+          </ul>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/src/app/users/[userid]/_componets/UserProfile.tsx
+++ b/src/app/users/[userid]/_componets/UserProfile.tsx
@@ -1,3 +1,5 @@
+//TODO:UserProfile componet 사용할지말지 width 7,9rem 둘중하나
+
 type TUserProfileProps = {
   url: string;
   center?: boolean;

--- a/src/app/users/[userid]/_pages/MyBookMarkList.tsx
+++ b/src/app/users/[userid]/_pages/MyBookMarkList.tsx
@@ -1,5 +1,7 @@
 import * as Tabs from '@radix-ui/react-tabs';
 import MyPageHeader from '../_componets/MypageHeader';
+import { dummyCardList } from '@/dummy/mainPage';
+import Card from '@/components/common/Card';
 
 export default function MyBookMarkList() {
   return (
@@ -15,12 +17,53 @@ export default function MyBookMarkList() {
           </Tabs.Trigger>
         </Tabs.List>
         <div className="py-5">
-          <Tabs.Content value="스터디" className="flex flex-col gap-[1.4rem]">
-            스터디 컨텐츠
+          <Tabs.Content value="스터디" className="flex flex-col gap-[1rem]">
+            <div className="flex flex-wrap gap-2">
+              {dummyCardList &&
+                dummyCardList.map((card) => (
+                  <div key={card.studyName}>
+                    <Card
+                      width="167"
+                      studyImage={card.studyImage}
+                      studyMeetings={card.studyMettings}
+                      studyTypeisBlue={card.studyTypeisBlue}
+                      studyType={card.studyType}
+                      studyCategoryisBlue={card.studyCategoryisBlue}
+                      studyCatecory={card.studyCatecory}
+                      studyName={card.studyName}
+                      studyStart={card.studyStart}
+                      studyEnd={card.studyEnd}
+                      studyPlace={card.studyPlace}
+                      studyJoinMember={card.studyJoinMember}
+                      studyMember={card.studyMember}
+                    />
+                  </div>
+                ))}
+            </div>
           </Tabs.Content>
           <Tabs.Content value="강의" className="flex flex-col gap-[1.4rem]">
-            {' '}
-            강의 컨텐츠
+            <div className="flex flex-wrap gap-3">
+              {dummyCardList &&
+                dummyCardList.map((card) => (
+                  <div key={card.studyName}>
+                    <Card
+                      width="167"
+                      studyImage={card.studyImage}
+                      studyMeetings={card.studyMettings}
+                      studyTypeisBlue={card.studyTypeisBlue}
+                      studyType={card.studyType}
+                      studyCategoryisBlue={card.studyCategoryisBlue}
+                      studyCatecory={card.studyCatecory}
+                      studyName={card.studyName}
+                      studyStart={card.studyStart}
+                      studyEnd={card.studyEnd}
+                      studyPlace={card.studyPlace}
+                      studyJoinMember={card.studyJoinMember}
+                      studyMember={card.studyMember}
+                    />
+                  </div>
+                ))}
+            </div>
           </Tabs.Content>
         </div>
       </Tabs.Root>

--- a/src/app/users/[userid]/_pages/MyBookMarkList.tsx
+++ b/src/app/users/[userid]/_pages/MyBookMarkList.tsx
@@ -1,0 +1,29 @@
+import * as Tabs from '@radix-ui/react-tabs';
+import MyPageHeader from '../_componets/MypageHeader';
+
+export default function MyBookMarkList() {
+  return (
+    <main>
+      <MyPageHeader>내 관심 목록</MyPageHeader>
+      <Tabs.Root defaultValue="스터디" className="mt-[2rem]">
+        <Tabs.List className="flex">
+          <Tabs.Trigger value="스터디" className="flex-1 minitab-trigger">
+            스터디
+          </Tabs.Trigger>
+          <Tabs.Trigger value="강의" className="flex-1 minitab-trigger">
+            강의
+          </Tabs.Trigger>
+        </Tabs.List>
+        <div className="py-5">
+          <Tabs.Content value="스터디" className="flex flex-col gap-[1.4rem]">
+            스터디 컨텐츠
+          </Tabs.Content>
+          <Tabs.Content value="강의" className="flex flex-col gap-[1.4rem]">
+            {' '}
+            강의 컨텐츠
+          </Tabs.Content>
+        </div>
+      </Tabs.Root>
+    </main>
+  );
+}

--- a/src/app/users/[userid]/_pages/MyPage.tsx
+++ b/src/app/users/[userid]/_pages/MyPage.tsx
@@ -1,0 +1,25 @@
+import SectionNavigator from '@/components/common/SectionNavigator';
+import MyPageHeader from '../_componets/MypageHeader';
+import MyPageProfileCard from '../_componets/MyPageProfileCard';
+import MyStudyInfo from '../_componets/MyStudyInfo';
+import SturingRate from '../_componets/SturingRate';
+
+export default function MyPage({ auth }: { auth?: boolean }) {
+  return (
+    <main>
+      <MyPageHeader>{auth && '마이페이지'}</MyPageHeader>
+      <section className="bg-gradient-to-r from-main-200  to-pink">
+        <MyPageProfileCard auth={auth} />
+        {auth && (
+          <div className="mt-[1.5rem]">
+            <MyStudyInfo />
+          </div>
+        )}
+      </section>
+      <SturingRate />
+      <SectionNavigator title="받은 스터디 평가 20" />
+      <SectionNavigator title="스터디 이력 5" />
+      {/* //Section Navigator 에 옆에 숫자 추가가능하도록하면 좋을거같음. */}
+    </main>
+  );
+}

--- a/src/app/users/[userid]/_pages/MyPage.tsx
+++ b/src/app/users/[userid]/_pages/MyPage.tsx
@@ -5,10 +5,11 @@ import MyStudyInfo from '../_componets/MyStudyInfo';
 import SturingRate from '../_componets/SturingRate';
 
 export default function MyPage({ auth }: { auth?: boolean }) {
+  const loginbg = auth && `bg-gradient-to-r from-main-200  to-pink`;
   return (
     <main>
       <MyPageHeader>{auth && '마이페이지'}</MyPageHeader>
-      <section className="bg-gradient-to-r from-main-200  to-pink">
+      <section className={`${loginbg}`}>
         <MyPageProfileCard auth={auth} />
         {auth && (
           <div className="mt-[1.5rem]">
@@ -18,7 +19,7 @@ export default function MyPage({ auth }: { auth?: boolean }) {
       </section>
       <SturingRate />
       <SectionNavigator title="받은 스터디 평가 20" />
-      <SectionNavigator title="스터디 이력 5" />
+      {!auth && <SectionNavigator title="스터디 이력 5" />}
       {/* //Section Navigator 에 옆에 숫자 추가가능하도록하면 좋을거같음. */}
     </main>
   );

--- a/src/app/users/[userid]/_pages/MyPageDetail.tsx
+++ b/src/app/users/[userid]/_pages/MyPageDetail.tsx
@@ -1,16 +1,20 @@
 import MyPageHeader from '../_componets/MypageHeader';
 import UserDetailInfo from '../_componets/UserDetailInfo';
-import UserProfile from '../_componets/UserProfile';
+import { FaCamera } from 'react-icons/fa';
 
 export default function MyPageDetail() {
   return (
     <main>
       <MyPageHeader>내정보</MyPageHeader>
-      <div className="py-[2.4rem] px-[14.3rem]">
+      <div className="py-[2.4rem] px-[14.3rem] ">
         <div
-          className={`w-[9rem] h-[9rem] border border-gray-500 rounded-full m-auto `}
+          className={`w-[9rem] h-[9rem] border border-gray-500 rounded-full m-auto relative `}
         >
           <img src="/images/user-card-dummy.png" className="object-fit"></img>
+          <FaCamera
+            size={16}
+            className="text-gray-600  border  border-gray-500 rounded-full bg-gray-300 p-1 absolute right-0 bottom-0"
+          />
         </div>
       </div>
       <UserDetailInfo />

--- a/src/app/users/[userid]/_pages/MyPageDetail.tsx
+++ b/src/app/users/[userid]/_pages/MyPageDetail.tsx
@@ -1,6 +1,7 @@
 import MyPageHeader from '../_componets/MypageHeader';
 import UserDetailInfo from '../_componets/UserDetailInfo';
 import { FaCamera } from 'react-icons/fa';
+import UserMatchingInfo from '../_componets/UserMatchingInfo';
 
 export default function MyPageDetail() {
   return (
@@ -18,6 +19,7 @@ export default function MyPageDetail() {
         </div>
       </div>
       <UserDetailInfo />
+      <UserMatchingInfo />
     </main>
   );
 }

--- a/src/app/users/[userid]/_pages/MyStudyReviewList.tsx
+++ b/src/app/users/[userid]/_pages/MyStudyReviewList.tsx
@@ -1,14 +1,12 @@
 import { GoChevronLeft } from 'react-icons/go';
 import StudyReviewCard from '../_componets/StudyReviewCard';
+import MyPageHeader from '../_componets/MypageHeader';
 
 export default function MyStudyReviewList() {
   const number = [1, 2, 3, 4];
   return (
-    <main className="px-[1.6rem] py-[2rem]">
-      <header className="flex text-center pb-[2rem] border-b-2 border-gray-600">
-        <GoChevronLeft size={24} className="mb-4" />
-        <h1 className="flex-1">받은 스터디 평가</h1>
-      </header>
+    <main >
+      <MyPageHeader>받은 스터디 평가</MyPageHeader>
       <div className="mt-[2rem]">후기 {number.length}개</div>
       <div className="flex flex-col gap-[2rem] ">
         {number.map((num) => {

--- a/src/app/users/[userid]/_pages/MyStudyReviewList.tsx
+++ b/src/app/users/[userid]/_pages/MyStudyReviewList.tsx
@@ -1,0 +1,20 @@
+import { GoChevronLeft } from 'react-icons/go';
+import StudyReviewCard from '../_componets/StudyReviewCard';
+
+export default function MyStudyReviewList() {
+  const number = [1, 2, 3, 4];
+  return (
+    <main className="px-[1.6rem] py-[2rem]">
+      <header className="flex text-center pb-[2rem] border-b-2 border-gray-600">
+        <GoChevronLeft size={24} className="mb-4" />
+        <h1 className="flex-1">받은 스터디 평가</h1>
+      </header>
+      <div className="mt-[2rem]">후기 {number.length}개</div>
+      <div className="flex flex-col gap-[2rem] ">
+        {number.map((num) => {
+          return <StudyReviewCard key={num} />;
+        })}
+      </div>
+    </main>
+  );
+}

--- a/src/app/users/[userid]/_pages/MyStudyReviewList.tsx
+++ b/src/app/users/[userid]/_pages/MyStudyReviewList.tsx
@@ -1,14 +1,13 @@
-import { GoChevronLeft } from 'react-icons/go';
 import StudyReviewCard from '../_componets/StudyReviewCard';
 import MyPageHeader from '../_componets/MypageHeader';
 
 export default function MyStudyReviewList() {
   const number = [1, 2, 3, 4];
   return (
-    <main >
+    <main>
       <MyPageHeader>받은 스터디 평가</MyPageHeader>
       <div className="mt-[2rem]">후기 {number.length}개</div>
-      <div className="flex flex-col gap-[2rem] ">
+      <div className="flex flex-col gap-[2rem] mt-[2rem] ">
         {number.map((num) => {
           return <StudyReviewCard key={num} />;
         })}

--- a/src/app/users/[userid]/_pages/StudyLog.tsx
+++ b/src/app/users/[userid]/_pages/StudyLog.tsx
@@ -1,0 +1,32 @@
+import Card from '@/components/common/Card';
+import MyPageHeader from '../_componets/MypageHeader';
+import { dummyCardList } from '@/dummy/mainPage';
+
+export default function StudyLog() {
+  return (
+    <main>
+      <MyPageHeader>스터디 이력</MyPageHeader>
+      <section className="flex flex-wrap gap-2 px-[1.6rem] py-[2.0rem]">
+        {dummyCardList &&
+          dummyCardList.map((card) => (
+            <div key={card.studyName}>
+              <Card
+                studyImage={card.studyImage}
+                studyMeetings={card.studyMettings}
+                studyTypeisBlue={card.studyTypeisBlue}
+                studyType={card.studyType}
+                studyCategoryisBlue={card.studyCategoryisBlue}
+                studyCatecory={card.studyCatecory}
+                studyName={card.studyName}
+                studyStart={card.studyStart}
+                studyEnd={card.studyEnd}
+                studyPlace={card.studyPlace}
+                studyJoinMember={card.studyJoinMember}
+                studyMember={card.studyMember}
+              />
+            </div>
+          ))}
+      </section>
+    </main>
+  );
+}

--- a/src/app/users/[userid]/_pages/StudyLog.tsx
+++ b/src/app/users/[userid]/_pages/StudyLog.tsx
@@ -6,11 +6,12 @@ export default function StudyLog() {
   return (
     <main>
       <MyPageHeader>스터디 이력</MyPageHeader>
-      <section className="flex flex-wrap gap-2 px-[1.6rem] py-[2.0rem]">
+      <section className="flex flex-wrap gap-2  py-[2rem] ">
         {dummyCardList &&
           dummyCardList.map((card) => (
             <div key={card.studyName}>
               <Card
+                width="167"
                 studyImage={card.studyImage}
                 studyMeetings={card.studyMettings}
                 studyTypeisBlue={card.studyTypeisBlue}

--- a/src/app/users/[userid]/layout.tsx
+++ b/src/app/users/[userid]/layout.tsx
@@ -3,5 +3,5 @@ export default function MyPageLayout({
 }: {
   children: React.ReactNode;
 }) {
-  return <div>{children}</div>;
+  return <div className="px-[1.6rem] py-[2rem]">{children}</div>;
 }

--- a/src/app/users/[userid]/layout.tsx
+++ b/src/app/users/[userid]/layout.tsx
@@ -1,0 +1,7 @@
+export default function MyPageLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <div>{children}</div>;
+}

--- a/src/app/users/[userid]/page.tsx
+++ b/src/app/users/[userid]/page.tsx
@@ -1,3 +1,4 @@
+import AccountCancelMoadl from './_componets/AccountCancelModal';
 import StudyReviewCard from './_componets/StudyReviewCard';
 import MyBookMarkList from './_pages/MyBookMarkList';
 import MyPage from './_pages/MyPage';
@@ -8,7 +9,7 @@ import StudyLog from './_pages/StudyLog';
 export default function page() {
   return (
     <div>
-      <MyPageDetail />
+      <AccountCancelMoadl />
     </div>
   );
 }

--- a/src/app/users/[userid]/page.tsx
+++ b/src/app/users/[userid]/page.tsx
@@ -7,9 +7,7 @@ import StudyLog from './_pages/StudyLog';
 export default function page() {
   return (
     <div>
-      {/* <MyPage auth={true} /> */}
-      <StudyLog />
-      <MyBookMarkList />
+      <MyPage auth={false} />
     </div>
   );
 }

--- a/src/app/users/[userid]/page.tsx
+++ b/src/app/users/[userid]/page.tsx
@@ -1,11 +1,13 @@
 import StudyReviewCard from './_componets/StudyReviewCard';
+import MyBookMarkList from './_pages/MyBookMarkList';
+import MyPage from './_pages/MyPage';
 import MyStudyReviewList from './_pages/MyStudyReviewList';
 import StudyLog from './_pages/StudyLog';
 
 export default function page() {
   return (
     <div>
-      <StudyLog />
+      <MyPage auth={true} />
     </div>
   );
 }

--- a/src/app/users/[userid]/page.tsx
+++ b/src/app/users/[userid]/page.tsx
@@ -1,10 +1,11 @@
 import StudyReviewCard from './_componets/StudyReviewCard';
 import MyStudyReviewList from './_pages/MyStudyReviewList';
+import StudyLog from './_pages/StudyLog';
 
 export default function page() {
   return (
     <div>
-      <MyStudyReviewList />
+      <StudyLog />
     </div>
   );
 }

--- a/src/app/users/[userid]/page.tsx
+++ b/src/app/users/[userid]/page.tsx
@@ -7,7 +7,9 @@ import StudyLog from './_pages/StudyLog';
 export default function page() {
   return (
     <div>
-      <MyPage auth={true} />
+      {/* <MyPage auth={true} /> */}
+      <StudyLog />
+      <MyBookMarkList />
     </div>
   );
 }

--- a/src/app/users/[userid]/page.tsx
+++ b/src/app/users/[userid]/page.tsx
@@ -1,0 +1,10 @@
+import StudyReviewCard from './_componets/StudyReviewCard';
+import MyStudyReviewList from './_pages/MyStudyReviewList';
+
+export default function page() {
+  return (
+    <div>
+      <MyStudyReviewList />
+    </div>
+  );
+}

--- a/src/app/users/[userid]/page.tsx
+++ b/src/app/users/[userid]/page.tsx
@@ -1,4 +1,5 @@
 import AccountCancelMoadl from './_componets/AccountCancelModal';
+import MiniAgreeModal from './_componets/MiniAgreeModal';
 import StudyReviewCard from './_componets/StudyReviewCard';
 import MyBookMarkList from './_pages/MyBookMarkList';
 import MyPage from './_pages/MyPage';
@@ -9,7 +10,7 @@ import StudyLog from './_pages/StudyLog';
 export default function page() {
   return (
     <div>
-      <AccountCancelMoadl />
+      <MiniAgreeModal />
     </div>
   );
 }

--- a/src/app/users/[userid]/page.tsx
+++ b/src/app/users/[userid]/page.tsx
@@ -10,7 +10,7 @@ import StudyLog from './_pages/StudyLog';
 export default function page() {
   return (
     <div>
-      <MiniAgreeModal />
+      <MyStudyReviewList />
     </div>
   );
 }

--- a/src/app/users/[userid]/page.tsx
+++ b/src/app/users/[userid]/page.tsx
@@ -10,7 +10,7 @@ import StudyLog from './_pages/StudyLog';
 export default function page() {
   return (
     <div>
-      <MyStudyReviewList />
+      <MyPageDetail />
     </div>
   );
 }

--- a/src/components/(jonghoo)/MatchingContainer.tsx
+++ b/src/components/(jonghoo)/MatchingContainer.tsx
@@ -5,7 +5,7 @@ export default function MatchingContainer({
 }) {
   {
     return (
-      <div className="w-[34.4rem] h-[6.4rem] rounded-[0.5rem] border-[0.1rem] border-gray-500 py-[2rem] px-[2.4rem] text-content-1">
+      <div className="w-full h-[6.4rem] rounded-[0.5rem] border-[0.1rem] border-gray-500 py-[2rem] px-[2.4rem] text-content-1">
         {children}
       </div>
     );

--- a/src/components/(jonghoo)/MatchingFooter.tsx
+++ b/src/components/(jonghoo)/MatchingFooter.tsx
@@ -10,7 +10,7 @@ export default function MatchingFooter({
   Backward: () => void;
 }) {
   return (
-    <footer className="flex justify-between w-full  px-[1.6rem] absolute bottom-[-10rem] right-[10%] ">
+    <footer className="flex justify-between w-full  px-[1.6rem] absolute bottom-[-10rem] right-[1%] ">
       {step === 1 ? (
         <div></div>
       ) : (

--- a/src/components/(jonghoo)/MatchingFooter.tsx
+++ b/src/components/(jonghoo)/MatchingFooter.tsx
@@ -10,7 +10,7 @@ export default function MatchingFooter({
   Backward: () => void;
 }) {
   return (
-    <footer className="flex justify-between w-[36.5rem]   px-[1.6rem] absolute bottom-0">
+    <footer className="flex justify-between w-full  px-[1.6rem] absolute bottom-[-10rem] right-[10%] ">
       {step === 1 ? (
         <div></div>
       ) : (

--- a/src/components/(jonghoo)/SelectMatching.tsx
+++ b/src/components/(jonghoo)/SelectMatching.tsx
@@ -10,7 +10,7 @@ export default function SelectMatching({
   let size = type === 'interest' ? ' h-[9rem]' : 'h-[7rem]';
   return (
     <div
-      className={`w-[16.4rem] ${size} border border-gray-300 flex items-center justify-center rounded-lg`}
+      className={`min-w-[16.4rem] max-w-[27rem] w-5/12 ${size} border border-gray-300 flex items-center justify-center rounded-lg gap-2`}
     >
       {children}
     </div>

--- a/src/components/common/Tab/CommonTab.tsx
+++ b/src/components/common/Tab/CommonTab.tsx
@@ -41,16 +41,16 @@ export default function CommonTab() {
         </label>
       </>
 
-      <Tabs.Root defaultValue="서울" className="flex  ">
-        <Tabs.List className="flex flex-col   w-[13.2rem] text-[1.4rem] text-[#909090]">
-          <ScrollArea.Root className="w-full h-[33.3rem]  overflow-hidden  bg-white">
+      <Tabs.Root defaultValue="서울" className="flex w-full  ">
+        <Tabs.List className="flex flex-col    w-[33%] text-[1.4rem] text-[#909090]">
+          <ScrollArea.Root className=" h-[33.3rem]    bg-white">
             <ScrollArea.Viewport className="w-full h-full ">
               {Object.keys(area).map((key, index) => {
                 return (
                   <Tabs.Trigger
                     value={`${key}`}
                     key={index}
-                    className={`w-[13.2rem] h-[4.9rem] py-[1.4rem] px-[4.65rem] tab-trigger`}
+                    className={` w-full md:max-w-[13.3rem]  h-[4.9rem] py-[1.4rem] px-[4.65rem] tab-trigger`}
                   >
                     {key}
                   </Tabs.Trigger>
@@ -62,45 +62,46 @@ export default function CommonTab() {
             </ScrollArea.Scrollbar>
           </ScrollArea.Root>
         </Tabs.List>
+        <Tabs.List className="w-[63%]">
+          {Object.keys(area).map((key: string, index) => {
+            return (
+              <Tabs.Content value={`${key}`} key={index}>
+                <ScrollArea.Root className=" h-[33.3rem]  overflow-hidden  ">
+                  <ScrollArea.Viewport className="w-full h-full overflow-auto ">
+                    {area[key].map((item: any, index) => {
+                      let newid: string = item;
 
-        {Object.keys(area).map((key: string, index) => {
-          return (
-            <Tabs.Content value={`${key}`} key={index}>
-              <ScrollArea.Root className="w-[24rem] h-[33.3rem]  overflow-hidden  ">
-                <ScrollArea.Viewport className="w-full h-full overflow-auto ">
-                  {area[key].map((item: any, index) => {
-                    let newid: string = item;
-
-                    const bg = selected.includes(newid)
-                      ? 'bg-[#ECF1FF] text-[#4171FF]'
-                      : 'bg-white';
-                    return (
-                      <Tabs.Content
-                        value={`${key}`}
-                        key={index}
-                        className={`${bg}  w-[24rem] h-[4.9rem] py-[1.4rem] ps-[2rem] border-b-[0.1rem] border-[#E4E4E4]`}
-                        onClick={() => {
-                          onSelectContent(item);
-                        }}
-                      >
-                        <p className="w-[90%]">{item}</p>
-                      </Tabs.Content>
-                    );
-                  })}
-                </ScrollArea.Viewport>
-                <ScrollArea.Scrollbar
-                  forceMount={true}
-                  className="flex select-none touch-none p-0.5 bg-transparent transition-colors duration-160 ease-out hover:bg-gray-200 data-[orientation=vertical]:w-2 data-[orientation=horizontal]:flex-col data-[orientation=horizontal]:h-2"
-                  orientation="vertical"
-                >
-                  <ScrollArea.Thumb className="flex-1 h-[90%] bg-[#D0D0D0] rounded-[4px]  " />
-                </ScrollArea.Scrollbar>
-              </ScrollArea.Root>
-            </Tabs.Content>
-          );
-        })}
+                      const bg = selected.includes(newid)
+                        ? 'bg-[#ECF1FF] text-[#4171FF]'
+                        : 'bg-white';
+                      return (
+                        <Tabs.Content
+                          value={`${key}`}
+                          key={index}
+                          className={`${bg}  w-full h-[4.9rem] py-[1.4rem] ps-[2rem] border-b-[0.1rem] border-[#E4E4E4]`}
+                          onClick={() => {
+                            onSelectContent(item);
+                          }}
+                        >
+                          <p className="w-[90%]">{item}</p>
+                        </Tabs.Content>
+                      );
+                    })}
+                  </ScrollArea.Viewport>
+                  <ScrollArea.Scrollbar
+                    forceMount={true}
+                    className="flex select-none touch-none p-0.5 bg-transparent transition-colors duration-160 ease-out hover:bg-gray-200 data-[orientation=vertical]:w-2 data-[orientation=horizontal]:flex-col data-[orientation=horizontal]:h-2"
+                    orientation="vertical"
+                  >
+                    <ScrollArea.Thumb className="flex-1 h-[90%] bg-[#D0D0D0] rounded-[4px]  " />
+                  </ScrollArea.Scrollbar>
+                </ScrollArea.Root>
+              </Tabs.Content>
+            );
+          })}
+        </Tabs.List>
       </Tabs.Root>
-      <div className="flex gap-4 p-4 flex-wrap">
+      <div className="flex gap-4 p-4 flex-wrap m-auto">
         {selected.map((item, index) => {
           return (
             <TabLabel

--- a/src/components/common/Tab/CommonTab.tsx
+++ b/src/components/common/Tab/CommonTab.tsx
@@ -22,7 +22,7 @@ export default function CommonTab() {
     setSelected(filter);
   };
   return (
-    <div className="flex flex-col gap-3">
+    <div className="flex flex-col gap-3 w-full, overflow-y-hidden">
       <>
         <label
           htmlFor="search-input"
@@ -41,9 +41,9 @@ export default function CommonTab() {
         </label>
       </>
 
-      <Tabs.Root defaultValue="서울" className="flex ">
+      <Tabs.Root defaultValue="서울" className="flex  ">
         <Tabs.List className="flex flex-col   w-[13.2rem] text-[1.4rem] text-[#909090]">
-          <ScrollArea.Root className="w-[13.2rem] h-[33.3rem]  overflow-hidden  bg-white">
+          <ScrollArea.Root className="w-full h-[33.3rem]  overflow-hidden  bg-white">
             <ScrollArea.Viewport className="w-full h-full ">
               {Object.keys(area).map((key, index) => {
                 return (
@@ -100,7 +100,7 @@ export default function CommonTab() {
           );
         })}
       </Tabs.Root>
-      <div className="flex gap-4 p-4">
+      <div className="flex gap-4 p-4 flex-wrap">
         {selected.map((item, index) => {
           return (
             <TabLabel

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -27,6 +27,12 @@ const config: Config = {
         'main-200': 'rgba(217, 227, 255, 1)',
         'main-100': 'rgba(236, 241, 255, 1)',
         red: 'rgba(255, 65, 65, 1)',
+        pink: 'rgba(255,228,224,0.5)',
+
+        accent: {
+          DEFAULT: 'hsl(var(--accent))',
+          foreground: 'hsl(var(--accent-foreground))',
+        },
       },
       fontSize: {
         'large-title': '2.4rem',

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -27,6 +27,7 @@ const config: Config = {
         'main-200': 'rgba(217, 227, 255, 1)',
         'main-100': 'rgba(236, 241, 255, 1)',
         red: 'rgba(255, 65, 65, 1)',
+        pink: 'rgba(255,228,224,0.5)',
       },
       fontSize: {
         'large-title': '2.4rem',


### PR DESCRIPTION
### 🖼️ Screen shot
| 관심목록 | 남이보는 내프로필 | 내가보는 내프로필 |
|-----------|---------------------|------------------------|
| ![Watchlist](https://github.com/Woongjin-Udemy-Pixe11/sturing/assets/124956289/2b2c9782-fadd-4dda-b835-6021718efa75) | ![Nami’s profile page](https://github.com/Woongjin-Udemy-Pixe11/sturing/assets/124956289/a8be6015-5668-411e-a8a4-d345b02e56e7) | ![My profile as I see it](https://github.com/Woongjin-Udemy-Pixe11/sturing/assets/124956289/a0b5a87c-8693-4559-8f6a-253655f85430) |

| 받은 스터디평가 | 스터디 이력 | 탈퇴 동의 모달 |
|---------------------------|-------------------|-------------------------------|
| ![Received study evaluation](https://github.com/Woongjin-Udemy-Pixe11/sturing/assets/124956289/e3a853c9-c447-46fb-9f75-bbb608603da5) | ![Study history page](https://github.com/Woongjin-Udemy-Pixe11/sturing/assets/124956289/7dd7b82e-f87a-4129-84c6-8b8308e02c95) | ![Small withdrawal consent modal](https://github.com/Woongjin-Udemy-Pixe11/sturing/assets/124956289/e61c2dfb-8049-4009-bfbe-645121e37155) |

| 회원 탈퇴 모달 ||
|-----------------------------|----|
| ![Membership withdrawal modal](https://github.com/Woongjin-Udemy-Pixe11/sturing/assets/124956289/22dbbc56-435a-4587-a888-2ab8b22661ef) |![ezgif com-video-to-gif-converter](https://github.com/Woongjin-Udemy-Pixe11/sturing/assets/124956289/3d459420-ebf0-4dda-bef9-d8030be06b57)


### 📝 Details

- 관심목록 컴포넌트
- 남이 보는 내프로필
- 내가보는 내프로필
 -> auth 인증 상태에따라 같은 컴포넌트에서 달라짐
- 받은 스터디 평가
- 스터디 이력
- 회원 탈퇴 모달
- 탈퇴 동의 모달
- 유저정보 디테일페이지
  - 수정버튼시 인풋창으로 변함
  - 아직 링크연결은 안됨(매칭과)

---
2024-06-27 추가
- Matching Componet 반응형 적용
- Common Tap, Componet width 적용

### 💬 Thinking
1. 모달 구현을 state로할지 layout 으로할지 안정해서 연결은 고민해보고하겠습니다.
2. 공통컴포넌트로 뺄수있을만한 부분들이 조금있어서 고려해보고 빼도록하겠습니다.
3. 유저정보는 어떻게 받아서 아래로뿌려줄지 고민중이라 정보는 하드코딩되어있습니다.


