### PR TITLE
[design] 메인, 검색, 검색 결과 페이지 레이아웃 적용

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -12,7 +12,9 @@ export default function RootLayout({
 }) {
   return (
     <html lang="ko">
-      <body className="w-[375px] m-auto">{children}</body>
+      <body className="w-screen overflow-x-hidden border border-black max-w-screen-md m-auto relative">
+        {children}
+      </body>
     </html>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -30,8 +30,10 @@ export default function page() {
       <SearchLabelList />
       <hr className="w-full block h-[0.8rem] bg-gray-100 border-0 my-[4rem]" />
       <SectionNavigator title="이번주 인기 스터디" moveLink="/search" />
+      {/* TODO: 스터디 카드 클릭 시 페이지 이동, Tab으로 접근, cursor-pointer */}
       <StudyCardList />
       <SectionNavigator title="새로 개설된 스터디" moveLink="/search" />
+      {/* TODO: 스터디 카드 클릭 시 페이지 이동, Tab으로 접근, cursor-pointer */}
       <StudyCardList />
       <span className="w-full px-[1.6rem] flex justify-between items-center text-headline-3 font-semibold mb-[2rem] mt-[4rem]">
         스터링 활동 우수 팀원

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -1,24 +1,48 @@
+'use client';
 import { IoMenu } from 'react-icons/io5';
 import { IoPersonOutline } from 'react-icons/io5';
 import { GoBell } from 'react-icons/go';
+import Link from 'next/link';
+import { useState } from 'react';
+import SideBar from '../sidebar/SideBar';
 
 export default function Header() {
+  const [isOpenMenu, setIsOpenMenu] = useState(false);
+
+  const onClickMenu = () => {
+    setIsOpenMenu(!isOpenMenu);
+    if (!isOpenMenu) {
+      document.body.style.overflow = 'hidden';
+    } else {
+      document.body.style.overflow = 'auto';
+    }
+  };
+
   return (
     <>
-      <header className=" w-full h-[5.4rem] flex justify-between items-center px-[0.8rem] text-gray-1000">
-        <div className=" w-[50%] flex justify-start items-center gap-[0.8rem]">
-          <button>
-            <IoMenu className="w-[2.4rem] h-[2.4rem]" />
+      {isOpenMenu && (
+        <div
+          className="fixed inset-0 bg-black bg-opacity-50 z-10"
+          onClick={onClickMenu}
+        ></div>
+      )}
+      {isOpenMenu && <SideBar onClose={onClickMenu} />}
+      <header className="w-full h-[5.4rem] flex justify-between items-center px-[0.8rem] text-gray-1000 m-0">
+        <div className="w-[50%] flex justify-start items-center gap-[0.8rem]">
+          <button onClick={onClickMenu}>
+            <IoMenu className="w-[2.8rem] h-[2.8rem]" />
           </button>
-          <h1 className="w-[7.8rem] h-[2.4rem] cursor-pointer">
-            <figure>
-              <img src="/logo.svg" alt="스터링 로고" className="w-full" />
-              <figcaption className="sr-only">
-                영어로 "sturing"이 쓰여있고, 글씨는 검정색입니다. 그리스 문자
-                감마와 비슷하게 생긴 "r"과 "i"의 타이틀은 파란색입니다.
-              </figcaption>
-            </figure>
-          </h1>
+          <Link href="/">
+            <h1 className="w-[7.8rem] h-[2.4rem] cursor-pointer">
+              <figure>
+                <img src="/logo.svg" alt="스터링 로고" className="w-full" />
+                <figcaption className="sr-only">
+                  영어로 "sturing"이 쓰여있고, 글씨는 검정색입니다. 그리스 문자
+                  감마와 비슷하게 생긴 "r"과 "i"의 타이틀은 파란색입니다.
+                </figcaption>
+              </figure>
+            </h1>
+          </Link>
         </div>
         <div className="w-[50%] flex justify-end items-center gap-[1.2rem]">
           <button>

--- a/src/components/common/ScrollableContainer.tsx
+++ b/src/components/common/ScrollableContainer.tsx
@@ -5,7 +5,7 @@ type TScrollableContainer = {
 export default function ScrollableContainer(props: TScrollableContainer) {
   const { children } = props;
   return (
-    <ul className="w-full overflow-y-auto flex gap-[0.8rem] px-[1.6rem] mb-[4rem]">
+    <ul className="w-full overflow-y-auto flex gap-[1.6rem]  px-[1.6rem] mb-[4rem]">
       {children}
     </ul>
   );

--- a/src/components/common/StudyCardList.tsx
+++ b/src/components/common/StudyCardList.tsx
@@ -6,9 +6,10 @@ export default function StudyCardList() {
   return (
     <ScrollableContainer>
       {dummyCardList &&
-        dummyCardList.map((card) => (
-          <li key={card.studyName}>
+        dummyCardList.map((card, index) => (
+          <li key={index}>
             <Card
+              width="182"
               studyImage={card.studyImage}
               studyMeetings={card.studyMettings}
               studyTypeisBlue={card.studyTypeisBlue}

--- a/src/components/main/Banner.tsx
+++ b/src/components/main/Banner.tsx
@@ -1,7 +1,8 @@
 export default function Banner() {
   return (
-    <figure>
+    <figure className="w-full">
       <img
+        className="w-full"
         src="/images/main-banner.png"
         alt="스터디 출석률 100% 달성하면 혜택을 받을 수 있는 이벤트 배너 이미지"
       />

--- a/src/components/main/SearchLabelList.tsx
+++ b/src/components/main/SearchLabelList.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link';
 import ScrollableContainer from '../common/ScrollableContainer';
 import { searchLabelList } from '@/constant/searchLabelList';
 
@@ -6,21 +7,23 @@ export default function SearchLabelList() {
     <ScrollableContainer>
       {searchLabelList &&
         searchLabelList.map((label) => (
-          <li
-            key={label.title}
-            className="flex gap-[0.8rem] px-[0.8rem] py-[0.6rem] rounded-[2.5rem] border-2 cursor-pointer"
-          >
-            <figure className="w-[2.4rem] h-[2.4rem] bg-gray-200 rounded-[50%] flex items-center  justify-center">
-              <img
-                src={label.imgSrc}
-                alt={label.imgAlt}
-                className="w-[1.6rem] h-[1.6rem]"
-              />
-              <figcaption className="sr-only">
-                {label.title}를 검색하러 이동합니다.
-              </figcaption>
-            </figure>
-            <span className="whitespace-nowrap">{label.title}</span>
+          <li key={label.title}>
+            <Link
+              href={`/search/result?keyword=${label.title}`}
+              className="flex gap-[0.8rem] px-[0.8rem] py-[0.6rem] rounded-[2.5rem] border-2 cursor-pointer"
+            >
+              <figure className="w-[2.4rem] h-[2.4rem] bg-gray-200 rounded-[50%] flex items-center  justify-center">
+                <img
+                  src={label.imgSrc}
+                  alt={label.imgAlt}
+                  className="w-[1.6rem] h-[1.6rem]"
+                />
+                <figcaption className="sr-only">
+                  {label.title}를 검색하러 이동합니다.
+                </figcaption>
+              </figure>
+              <span className="whitespace-nowrap">{label.title}</span>
+            </Link>
           </li>
         ))}
     </ScrollableContainer>

--- a/src/components/main/UserCard.tsx
+++ b/src/components/main/UserCard.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link';
 import MainLabel from './MainLabel';
 
 type TUserCardProps = {
@@ -22,7 +23,8 @@ export default function UserCard(props: TUserCardProps) {
   } = props;
 
   return (
-    <div className="w-[13.4rem] flex flex-col gap-[.8rem]">
+    // TODO: '남'이 보는 마이 페이지 링크 자체 or 여기서 조합해야 함
+    <Link href={`my-page`} className="w-[13.4rem] flex flex-col gap-[.8rem]">
       <div className="w-full bg-main-200 rounded-[.5rem] p-[1.6rem] flex justify-center items-center flex-col">
         <img
           src={userImage}
@@ -51,6 +53,6 @@ export default function UserCard(props: TUserCardProps) {
           <MainLabel content={studyMoodContent} />
         </li>
       </ul>
-    </div>
+    </Link>
   );
 }

--- a/src/components/search/StudyList.tsx
+++ b/src/components/search/StudyList.tsx
@@ -12,7 +12,7 @@ export default function StudyList(props: TStudyListProps) {
   let cardList = dummyCardList;
 
   if (!isDetail) {
-    isFull = dummyCardList.length > 4;
+    isFull = dummyCardList.length > 4 ? true : false;
     cardList = dummyCardList.slice(0, 4);
   }
 
@@ -24,10 +24,10 @@ export default function StudyList(props: TStudyListProps) {
             스터디
           </span>
         )}
-        <ul className="w-full flex justify-between items-center flex-wrap gap-y-[.8rem] py-[2rem]">
+        <ul className="w-full pl-[1rem] flex justify-start items-center flex-wrap gap-x-[1.6rem] gap-y-[.8rem] py-[2rem]">
           {cardList &&
-            cardList.map((card, index) => (
-              <li key={index}>
+            cardList.map((card) => (
+              <li key={card.id}>
                 <Card
                   width="167"
                   studyImage={card.studyImage}

--- a/src/components/search/StudyList.tsx
+++ b/src/components/search/StudyList.tsx
@@ -24,7 +24,7 @@ export default function StudyList(props: TStudyListProps) {
             스터디
           </span>
         )}
-        <ul className="w-full pl-[1rem] flex justify-start items-center flex-wrap gap-x-[1.6rem] gap-y-[.8rem] py-[2rem]">
+        <ul className="w-full flex justify-stretch items-center flex-wrap gap-x-[1.6rem] gap-y-[.8rem] py-[2rem]">
           {cardList &&
             cardList.map((card) => (
               <li key={card.id}>

--- a/src/components/sidebar/SideBar.tsx
+++ b/src/components/sidebar/SideBar.tsx
@@ -3,10 +3,10 @@ import Link from 'next/link';
 import SideBarToggle from './SideBarToggle';
 import UserProfile from './UserProfile';
 
-export default function SideBar() {
+export default function SideBar({ onClose }: { onClose: () => void }) {
   return (
     <>
-      <dialog className="block fixed top-0 left-0 m-0 w-[32.4rem] px-[2.4rem] h-screen z-10">
+      <dialog className="block fixed top-0 left-0 w-[32.4rem] px-[2.4rem] h-screen z-10 ">
         <button className="absolute top-[4rem] right-[2.4rem] w-[2.4rem] h-[2.4rem]">
           <IoClose />
         </button>

--- a/src/dummy/mainPage.ts
+++ b/src/dummy/mainPage.ts
@@ -1,5 +1,6 @@
 export const dummyCardList = [
   {
+    id: 1,
     studyImage: '/images/card-dummy-img1.png',
     studyMettings: '스터디 시간 미정',
     studyTypeisBlue: true,
@@ -14,6 +15,7 @@ export const dummyCardList = [
     studyMember: 4,
   },
   {
+    id: 2,
     studyImage: '/images/card-dummy-img2.png',
     studyMettings: '모임 날짜 미정',
     studyTypeisBlue: true,
@@ -28,6 +30,7 @@ export const dummyCardList = [
     studyMember: 4,
   },
   {
+    id: 3,
     studyImage: '/images/card-dummy-img3.png',
     studyMettings: '매주 목 오후 8:00',
     studyTypeisBlue: true,
@@ -42,6 +45,7 @@ export const dummyCardList = [
     studyMember: 4,
   },
   {
+    id: 4,
     studyImage: '/images/card-dummy-img1.png',
     studyMettings: '스터디 시간 미정',
     studyTypeisBlue: true,
@@ -56,6 +60,7 @@ export const dummyCardList = [
     studyMember: 4,
   },
   {
+    id: 5,
     studyImage: '/images/card-dummy-img2.png',
     studyMettings: '모임 날짜 미정',
     studyTypeisBlue: true,
@@ -70,6 +75,7 @@ export const dummyCardList = [
     studyMember: 4,
   },
   {
+    id: 6,
     studyImage: '/images/card-dummy-img3.png',
     studyMettings: '매주 목 오후 8:00',
     studyTypeisBlue: true,


### PR DESCRIPTION
### 🖼️ Screen shot

| 완성 이미지/GIF | 완성 이미지/GIF | 완성 이미지/GIF |
| :-------------: | :-------------: | :-------------: |
| <img src='https://github.com/Woongjin-Udemy-Pixe11/sturing/assets/91606951/1aefc59c-a5a3-4f47-84c0-d9f5d2630047' />  | <img src='https://github.com/Woongjin-Udemy-Pixe11/sturing/assets/91606951/b38eaada-5a8a-4006-8148-1227f81a5c5a' />  |<img src='https://github.com/Woongjin-Udemy-Pixe11/sturing/assets/91606951/8443a411-8c1f-4b7f-a081-ea3d3b41add4' />  |



### 📝 Details

- 핸드폰 가로모드 지원을 위해 전체 레이아웃 최대 사이즈를 태블릿(768px)으로 수정했습니다. 
- tab으로 접근할 수 있도록, .`<Link>`, `<button>`으로 태그 변경하였습니다.
- 기기별 레이아웃 확인을 위해 [크롬 확장 프로그램](https://chromewebstore.google.com/detail/responsive-viewer/inmopeiepgfljkpkidclfgbgbmfcennb) 사용했습니다.
- 메인 페이지 레이아웃이 머지되지 않아 검색, 검색 결과 페이지 레이아웃도 feature/ryukyung-main에서 작업했습니다.