### PR TITLE
[feat] matching 컴포넌트 1차완성

### DIFF
--- a/src/app/(JH)/matching/_components/ClientMatching.tsx
+++ b/src/app/(JH)/matching/_components/ClientMatching.tsx
@@ -3,16 +3,17 @@
 import MatchingFooter from '@/components/(JH)/matching/MatchingFooter';
 import { GoChevronLeft } from 'react-icons/go';
 import Type from './Type';
-import { useState } from 'react';
+import { useReducer, useState } from 'react';
 import Interest from './Interest';
 import Field from './Field';
 import Region from './Region';
 import Mood from './Mood';
 import MatchingCompleted from './MatchingCompleted';
+import matchingreducer, { TActionType } from '@/utils/matchingreducer';
 
-type Tmatching = {
+export type Tmatching = {
   userid: string;
-  interests: string[];
+  interest: string[];
   level: {
     [key: string]: string;
   };
@@ -24,55 +25,37 @@ type Tmatching = {
 //TODO:전역으로 Tmatching 을 제외하는 방향도 나쁘지않을것같다.
 
 export default function ClientMatching() {
+  const [state, dispatch] = useReducer<React.Reducer<Tmatching, TActionType>>(
+    matchingreducer,
+    {
+      userid: '1',
+      interest: [],
+      level: {},
+      studyType: '',
+      preferRegion: [],
+      preferMood: [],
+    },
+  );
+  console.log(state);
   const [step, setStep] = useState<number>(1);
-  const [interest, setInterest] = useState<string[]>([]);
-  const [level, setLevel] = useState<{ [key: string]: string }>({});
-  const [studyType, setStudyType] = useState<string>('');
-  const [moods, setMood] = useState<string[]>([]);
-  const [regions, setRegion] = useState<string[]>([]);
-  let formData: Tmatching = {
-    userid: '1',
-    interests: interest,
-    level: level,
-    studyType: studyType,
-    preferRegion: regions,
-    preferMood: moods,
-  };
+
   const onClickInterest = (field: string) => {
-    if (interest.length === 3) {
-      interest.shift();
-    }
-    if (interest.includes(field)) {
-      setInterest((prev) => prev.filter((item) => item !== field));
-    } else {
-      setInterest((prev) => [...prev, field]);
-    }
+    dispatch({ type: 'setInterest', payload: field });
   };
+
   const onClickLevel = (field: string, level: string) => {
-    setLevel((prev) => ({ ...prev, [field]: level }));
+    dispatch({ type: 'setLevel', payload: { field, level } });
   };
   const onClickStudyType = (field: string) => {
-    setStudyType((prev) => field);
+    dispatch({ type: 'setStudyType', payload: field });
   };
+
   const onClickMood = (mood: string) => {
-    if (moods.length === 3) {
-      moods.shift();
-    }
-    if (moods.includes(mood)) {
-      setMood((prev) => prev.filter((item) => item !== mood));
-    } else {
-      setMood((prev) => [...prev, mood]);
-    }
+    dispatch({ type: 'setMood', payload: mood });
   };
+
   const onClickRegions = (region: string) => {
-    if (regions.length === 3) {
-      regions.shift();
-    }
-    if (regions.includes(region)) {
-      setRegion((prev) => prev.filter((item) => item !== region));
-    } else {
-      setRegion((prev) => [...prev, region]);
-    }
+    dispatch({ type: 'setRegion', payload: region });
   };
   const onClickForwardStep = () => {
     if (step === 6) {
@@ -87,14 +70,20 @@ export default function ClientMatching() {
     setStep((prev) => prev - 1);
   };
   const stepComponet: any = {
-    1: <Interest interest={interest} onClickInterest={onClickInterest} />,
-    2: <Field interest={interest} onClickLevel={onClickLevel} Level={level} />,
-    3: <Type studyType={studyType} onClickStudyType={onClickStudyType} />,
-    4: <Region regions={regions} onClickRegion={onClickRegions} />,
-    5: <Mood moods={moods} onClickMood={onClickMood} />,
+    1: <Interest interest={state.interest} onClickInterest={onClickInterest} />,
+    2: (
+      <Field
+        interest={state.interest}
+        onClickLevel={onClickLevel}
+        Level={state.level}
+      />
+    ),
+    3: <Type studyType={state.studyType} onClickStudyType={onClickStudyType} />,
+    4: <Region regions={state.preferRegion} onClickRegion={onClickRegions} />,
+    5: <Mood moods={state.preferMood} onClickMood={onClickMood} />,
     6: <MatchingCompleted />,
   };
-  console.log(formData);
+
   return (
     <main className="flex flex-col w-full  relative  ">
       <header>

--- a/src/app/(JH)/matching/_components/ClientMatching.tsx
+++ b/src/app/(JH)/matching/_components/ClientMatching.tsx
@@ -27,6 +27,8 @@ export default function ClientMatching() {
   const [step, setStep] = useState<number>(1);
   const [interest, setInterest] = useState<string[]>([]);
   const [level, setLevel] = useState<{ [key: string]: string }>({});
+  const [studyType, setStudyType] = useState<string>('');
+  const [moods, setMood] = useState<string[]>([]);
   const onClickInterest = (field: string) => {
     if (interest.length === 3) {
       interest.shift();
@@ -41,7 +43,19 @@ export default function ClientMatching() {
   const onClickLevel = (field: string, level: string) => {
     setLevel((prev) => ({ ...prev, [field]: level }));
   };
-
+  const onClickStudyType = (field: string) => {
+    setStudyType((prev) => field);
+  };
+  const onClickMood = (mood: string) => {
+    if (moods.length === 3) {
+      moods.shift();
+    }
+    if (moods.includes(mood)) {
+      setMood((prev) => prev.filter((item) => item !== mood));
+    } else {
+      setMood((prev) => [...prev, mood]);
+    }
+  };
   const onClickForwardStep = () => {
     if (step === 6) {
       return;
@@ -57,9 +71,9 @@ export default function ClientMatching() {
   const stepComponet: any = {
     1: <Interest interest={interest} onClickInterest={onClickInterest} />,
     2: <Field interest={interest} onClickLevel={onClickLevel} Level={level} />,
-    3: <Type />,
+    3: <Type studyType={studyType} onClickStudyType={onClickStudyType} />,
     4: <Region />,
-    5: <Mood />,
+    5: <Mood moods={moods} onClickMood={onClickMood} />,
     6: <MatchingCompleted />,
   };
   return (

--- a/src/app/(JH)/matching/_components/ClientMatching.tsx
+++ b/src/app/(JH)/matching/_components/ClientMatching.tsx
@@ -26,6 +26,7 @@ type Tmatching = {
 export default function ClientMatching() {
   const [step, setStep] = useState<number>(1);
   const [interest, setInterest] = useState<string[]>([]);
+  const [level, setLevel] = useState<{ [key: string]: string }>({});
   const onClickInterest = (field: string) => {
     if (interest.length === 3) {
       interest.shift();
@@ -37,7 +38,10 @@ export default function ClientMatching() {
       setInterest((prev) => [...prev, field]);
     }
   };
-  console.log(interest);
+  const onClickLevel = (field: string, level: string) => {
+    setLevel((prev) => ({ ...prev, [field]: level }));
+  };
+
   const onClickForwardStep = () => {
     if (step === 6) {
       return;
@@ -52,7 +56,7 @@ export default function ClientMatching() {
   };
   const stepComponet: any = {
     1: <Interest interest={interest} onClickInterest={onClickInterest} />,
-    2: <Field />,
+    2: <Field interest={interest} onClickLevel={onClickLevel} Level={level} />,
     3: <Type />,
     4: <Region />,
     5: <Mood />,

--- a/src/app/(JH)/matching/_components/ClientMatching.tsx
+++ b/src/app/(JH)/matching/_components/ClientMatching.tsx
@@ -61,6 +61,25 @@ export default function ClientMatching() {
     if (step === 6) {
       return;
     }
+    if (state.interest.length === 0 && step === 1) {
+      return;
+    }
+    if (
+      Object.keys(state.level).length !== state.interest.length &&
+      step === 2
+    ) {
+      return;
+    }
+    if (state.studyType === '' && step === 3) {
+      return;
+    }
+    if (state.preferRegion.length === 0 && step === 4) {
+      return;
+    }
+    if (state.preferMood.length === 0 && step === 5) {
+      return;
+    }
+
     setStep((prev) => prev + 1);
   };
   const onClickBackwardStep = () => {

--- a/src/app/(JH)/matching/_components/ClientMatching.tsx
+++ b/src/app/(JH)/matching/_components/ClientMatching.tsx
@@ -36,7 +36,7 @@ export default function ClientMatching() {
       preferMood: [],
     },
   );
-  console.log(state);
+
   const [step, setStep] = useState<number>(1);
 
   const onClickInterest = (field: string) => {
@@ -69,6 +69,7 @@ export default function ClientMatching() {
     }
     setStep((prev) => prev - 1);
   };
+  //TODO:dispatch 함수의 타입작성하기
   const stepComponet: any = {
     1: <Interest interest={state.interest} onClickInterest={onClickInterest} />,
     2: (

--- a/src/app/(JH)/matching/_components/ClientMatching.tsx
+++ b/src/app/(JH)/matching/_components/ClientMatching.tsx
@@ -10,8 +10,34 @@ import Region from './Region';
 import Mood from './Mood';
 import MatchingCompleted from './MatchingCompleted';
 
+type Tmatching = {
+  userid: string;
+  interests: string[];
+  level: {
+    [key: string]: string;
+  };
+  studyType: string;
+  preferRegion: string[];
+  preferMood: string[];
+};
+
+//TODO:전역으로 Tmatching 을 제외하는 방향도 나쁘지않을것같다.
+
 export default function ClientMatching() {
   const [step, setStep] = useState<number>(1);
+  const [interest, setInterest] = useState<string[]>([]);
+  const onClickInterest = (field: string) => {
+    if (interest.length === 3) {
+      interest.shift();
+    }
+    if (interest.includes(field)) {
+      console.log('true');
+      setInterest((prev) => prev.filter((item) => item !== field));
+    } else {
+      setInterest((prev) => [...prev, field]);
+    }
+  };
+  console.log(interest);
   const onClickForwardStep = () => {
     if (step === 6) {
       return;
@@ -25,7 +51,7 @@ export default function ClientMatching() {
     setStep((prev) => prev - 1);
   };
   const stepComponet: any = {
-    1: <Interest />,
+    1: <Interest interest={interest} onClickInterest={onClickInterest} />,
     2: <Field />,
     3: <Type />,
     4: <Region />,

--- a/src/app/(JH)/matching/_components/ClientMatching.tsx
+++ b/src/app/(JH)/matching/_components/ClientMatching.tsx
@@ -29,12 +29,20 @@ export default function ClientMatching() {
   const [level, setLevel] = useState<{ [key: string]: string }>({});
   const [studyType, setStudyType] = useState<string>('');
   const [moods, setMood] = useState<string[]>([]);
+  const [regions, setRegion] = useState<string[]>([]);
+  let formData: Tmatching = {
+    userid: '1',
+    interests: interest,
+    level: level,
+    studyType: studyType,
+    preferRegion: regions,
+    preferMood: moods,
+  };
   const onClickInterest = (field: string) => {
     if (interest.length === 3) {
       interest.shift();
     }
     if (interest.includes(field)) {
-      console.log('true');
       setInterest((prev) => prev.filter((item) => item !== field));
     } else {
       setInterest((prev) => [...prev, field]);
@@ -56,6 +64,16 @@ export default function ClientMatching() {
       setMood((prev) => [...prev, mood]);
     }
   };
+  const onClickRegions = (region: string) => {
+    if (regions.length === 3) {
+      regions.shift();
+    }
+    if (regions.includes(region)) {
+      setRegion((prev) => prev.filter((item) => item !== region));
+    } else {
+      setRegion((prev) => [...prev, region]);
+    }
+  };
   const onClickForwardStep = () => {
     if (step === 6) {
       return;
@@ -72,12 +90,13 @@ export default function ClientMatching() {
     1: <Interest interest={interest} onClickInterest={onClickInterest} />,
     2: <Field interest={interest} onClickLevel={onClickLevel} Level={level} />,
     3: <Type studyType={studyType} onClickStudyType={onClickStudyType} />,
-    4: <Region />,
+    4: <Region regions={regions} onClickRegion={onClickRegions} />,
     5: <Mood moods={moods} onClickMood={onClickMood} />,
     6: <MatchingCompleted />,
   };
+  console.log(formData);
   return (
-    <main className="flex flex-col w-full  relative mt-[6rem] ">
+    <main className="flex flex-col w-full  relative  ">
       <header>
         <GoChevronLeft size={30} className="mb-4" />
 

--- a/src/app/(JH)/matching/_components/Field.tsx
+++ b/src/app/(JH)/matching/_components/Field.tsx
@@ -3,7 +3,6 @@ import * as Tabs from '@radix-ui/react-tabs';
 import { level } from '@/constant/region';
 
 export default function Field({ interest, onClickLevel, Level }: any) {
-  console.log(Level);
   return (
     <div className="w-full px-[1.4rem]">
       <section className="py-[2rem] ">

--- a/src/app/(JH)/matching/_components/Field.tsx
+++ b/src/app/(JH)/matching/_components/Field.tsx
@@ -1,18 +1,9 @@
 import MatchingContainer from '@/components/(JH)/matching/MatchingContainer';
 import * as Tabs from '@radix-ui/react-tabs';
 import { level } from '@/constant/region';
-import MatchingFooter from '@/components/(JH)/matching/MatchingFooter';
-export default function Field() {
-  const levelComponet = Object.keys(level).map((key) => {
-    return (
-      <MatchingContainer key={key}>
-        <div className="flex gap-5">
-          <p>{key}</p>
-          <p>{level[key]}</p>
-        </div>
-      </MatchingContainer>
-    );
-  });
+
+export default function Field({ interest, onClickLevel, Level }: any) {
+  console.log(Level);
   return (
     <div className="w-full px-[1.4rem]">
       <section className="py-[2rem] ">
@@ -22,26 +13,43 @@ export default function Field() {
         </h1>
       </section>
       <section className="mt-[4rem] w-full">
-        <Tabs.Root defaultValue="디자인">
+        <Tabs.Root defaultValue={`${interest[0]}`}>
           <Tabs.List className="flex">
-            <Tabs.Trigger value="디자인" className="flex-1 minitab-trigger">
-              디자인
-            </Tabs.Trigger>
-            <Tabs.Trigger
-              value="기획,마케팅"
-              className="flex-1 minitab-trigger"
-            >
-              기획,마케팅
-            </Tabs.Trigger>
+            {interest.map((field: string) => {
+              return (
+                <Tabs.Trigger
+                  value={`${field}`}
+                  className="flex-1 minitab-trigger"
+                >
+                  {field}
+                </Tabs.Trigger>
+              );
+            })}
           </Tabs.List>
           <div className="py-5 ">
-            {/* //TODO: flex 일떄는 중앙정렬되는데, 해제하면 중앙이안됨 why? */}
-            <Tabs.Content value="디자인">
-              <div className="m-auto flex flex-col gap-3">{levelComponet}</div>
-            </Tabs.Content>
-            <Tabs.Content value="기획,마케팅">
-              <div className="m-auto flex flex-col gap-3">{levelComponet}</div>
-            </Tabs.Content>
+            {interest.map((field: string) => {
+              return (
+                <Tabs.Content value={`${field}`}>
+                  <div className="m-auto flex flex-col gap-3">
+                    {Object.keys(level).map((key) => {
+                      return (
+                        <MatchingContainer key={key}>
+                          <div
+                            className="flex gap-5"
+                            onClick={() => {
+                              onClickLevel(field, key);
+                            }}
+                          >
+                            <p>{key}</p>
+                            <p>{level[key]}</p>
+                          </div>
+                        </MatchingContainer>
+                      );
+                    })}
+                  </div>
+                </Tabs.Content>
+              );
+            })}
           </div>
         </Tabs.Root>
       </section>

--- a/src/app/(JH)/matching/_components/Field.tsx
+++ b/src/app/(JH)/matching/_components/Field.tsx
@@ -21,6 +21,7 @@ export default function Field({ interest, onClickLevel, Level }: any) {
                 <Tabs.Trigger
                   value={`${field}`}
                   className="flex-1 minitab-trigger"
+                  key={field}
                 >
                   {field}
                 </Tabs.Trigger>
@@ -30,7 +31,7 @@ export default function Field({ interest, onClickLevel, Level }: any) {
           <div className="py-5 ">
             {interest.map((field: string) => {
               return (
-                <Tabs.Content value={`${field}`}>
+                <Tabs.Content value={`${field}`} key={field}>
                   <div className="m-auto flex flex-col gap-3">
                     {Object.keys(level).map((key) => {
                       return (

--- a/src/app/(JH)/matching/_components/Field.tsx
+++ b/src/app/(JH)/matching/_components/Field.tsx
@@ -2,6 +2,8 @@ import MatchingContainer from '@/components/(JH)/matching/MatchingContainer';
 import * as Tabs from '@radix-ui/react-tabs';
 import { level } from '@/constant/region';
 
+//TODO:console.log(4번씩찍히는데 이거 최적화해서 memo, useCallback 해야될듯)
+
 export default function Field({ interest, onClickLevel, Level }: any) {
   return (
     <div className="w-full px-[1.4rem]">
@@ -32,7 +34,10 @@ export default function Field({ interest, onClickLevel, Level }: any) {
                   <div className="m-auto flex flex-col gap-3">
                     {Object.keys(level).map((key) => {
                       return (
-                        <MatchingContainer key={key}>
+                        <MatchingContainer
+                          key={key}
+                          active={Level[field] === key ? true : false}
+                        >
                           <div
                             className="flex gap-5"
                             onClick={() => {

--- a/src/app/(JH)/matching/_components/Interest.tsx
+++ b/src/app/(JH)/matching/_components/Interest.tsx
@@ -3,7 +3,14 @@ import SelectMatching from '@/components/(JH)/matching/SelectMatching';
 import { searchLabelList } from '@/constant/searchLabelList';
 import FlexContainer from '@/components/(JH)/matching/FlexContainer';
 
-export default function Interest({ onClickInterest }: any) {
+type TInterestProps = {
+  interest: string[];
+  onClickInterest: any;
+};
+
+export default function Interest(props: TInterestProps) {
+  const { interest, onClickInterest } = props;
+  console.log(interest);
   return (
     <div className="w-full px-[1.6rem] py-[2rem]">
       <section>
@@ -25,6 +32,7 @@ export default function Interest({ onClickInterest }: any) {
               onClick={() => {
                 onClickInterest(label.title);
               }}
+              active={interest.includes(label.title) ? true : false}
             >
               <img src={label.imgSrc} alt={label.imgAlt} />
               <div>{label.title}</div>

--- a/src/app/(JH)/matching/_components/Interest.tsx
+++ b/src/app/(JH)/matching/_components/Interest.tsx
@@ -3,12 +3,9 @@ import SelectMatching from '@/components/(JH)/matching/SelectMatching';
 import { searchLabelList } from '@/constant/searchLabelList';
 import FlexContainer from '@/components/(JH)/matching/FlexContainer';
 
-export default function Interest({ interest, onClickInterest }: any) {
+export default function Interest({ onClickInterest }: any) {
   return (
     <div className="w-full px-[1.6rem] py-[2rem]">
-      {interest.map((item: any) => (
-        <div>{item}</div>
-      ))}
       <section>
         <h1 className="font-black text-headline-3">웅진님 안녕하세요.</h1>{' '}
         <h1 className="font-black text-headline-3">

--- a/src/app/(JH)/matching/_components/Interest.tsx
+++ b/src/app/(JH)/matching/_components/Interest.tsx
@@ -1,10 +1,14 @@
+'use client';
 import SelectMatching from '@/components/(JH)/matching/SelectMatching';
 import { searchLabelList } from '@/constant/searchLabelList';
 import FlexContainer from '@/components/(JH)/matching/FlexContainer';
 
-export default function Interest() {
+export default function Interest({ interest, onClickInterest }: any) {
   return (
     <div className="w-full px-[1.6rem] py-[2rem]">
+      {interest.map((item: any) => (
+        <div>{item}</div>
+      ))}
       <section>
         <h1 className="font-black text-headline-3">웅진님 안녕하세요.</h1>{' '}
         <h1 className="font-black text-headline-3">
@@ -18,7 +22,13 @@ export default function Interest() {
         {searchLabelList
           .filter((label) => label.title !== '기타')
           .map((label) => (
-            <SelectMatching key={label.title} type="interest">
+            <SelectMatching
+              key={label.title}
+              type="interest"
+              onClick={() => {
+                onClickInterest(label.title);
+              }}
+            >
               <img src={label.imgSrc} alt={label.imgAlt} />
               <div>{label.title}</div>
             </SelectMatching>

--- a/src/app/(JH)/matching/_components/Mood.tsx
+++ b/src/app/(JH)/matching/_components/Mood.tsx
@@ -22,6 +22,7 @@ export default function Mood({ moods, onClickMood }: any) {
             onClick={() => {
               onClickMood(label.title);
             }}
+            active={moods.includes(label.title) && true}
           >
             <img src={label.imgSrc} alt={label.imgAlt} />
             <div className="ml-2">{label.title}</div>

--- a/src/app/(JH)/matching/_components/Mood.tsx
+++ b/src/app/(JH)/matching/_components/Mood.tsx
@@ -2,7 +2,8 @@ import FlexContainer from '@/components/(JH)/matching/FlexContainer';
 import SelectMatching from '@/components/(JH)/matching/SelectMatching';
 import { emojiLabelList } from '@/constant/emojiLabelList';
 
-export default function Mood() {
+export default function Mood({ moods, onClickMood }: any) {
+  console.log(moods);
   return (
     <div className="w-full px-[1.6rem] py-[2rem]">
       <section>
@@ -16,7 +17,13 @@ export default function Mood() {
       </section>
       <FlexContainer>
         {emojiLabelList.map((label) => (
-          <SelectMatching key={label.title} type="mood">
+          <SelectMatching
+            key={label.title}
+            type="mood"
+            onClick={() => {
+              onClickMood(label.title);
+            }}
+          >
             <img src={label.imgSrc} alt={label.imgAlt} />
             <div className="ml-2">{label.title}</div>
           </SelectMatching>

--- a/src/app/(JH)/matching/_components/Mood.tsx
+++ b/src/app/(JH)/matching/_components/Mood.tsx
@@ -3,7 +3,6 @@ import SelectMatching from '@/components/(JH)/matching/SelectMatching';
 import { emojiLabelList } from '@/constant/emojiLabelList';
 
 export default function Mood({ moods, onClickMood }: any) {
-  console.log(moods);
   return (
     <div className="w-full px-[1.6rem] py-[2rem]">
       <section>

--- a/src/app/(JH)/matching/_components/Region.tsx
+++ b/src/app/(JH)/matching/_components/Region.tsx
@@ -1,6 +1,6 @@
 import CommonTab from '@/components/common/Tab/CommonTab';
 
-export default function Region() {
+export default function Region({ regions, onClickRegion }: any) {
   return (
     <div className="w-full">
       <section className="pt-[2rem] px-[1.6rem]">
@@ -12,7 +12,7 @@ export default function Region() {
           최대 3개까지 선택 가능합니다.
         </p>
       </section>
-      <CommonTab />
+      <CommonTab regions={regions} onClickRegion={onClickRegion} />
     </div>
   );
 }

--- a/src/app/(JH)/matching/_components/Type.tsx
+++ b/src/app/(JH)/matching/_components/Type.tsx
@@ -2,7 +2,6 @@ import MatchingContainer from '@/components/(JH)/matching/MatchingContainer';
 import { FaCheck } from 'react-icons/fa6';
 
 export default function Type({ studyType, onClickStudyType }: any) {
-  console.log(studyType);
   return (
     <div className="w-full px-[1.4rem]">
       <section className="py-[2rem] ">

--- a/src/app/(JH)/matching/_components/Type.tsx
+++ b/src/app/(JH)/matching/_components/Type.tsx
@@ -1,7 +1,8 @@
 import MatchingContainer from '@/components/(JH)/matching/MatchingContainer';
 import { FaCheck } from 'react-icons/fa6';
 
-export default function Type() {
+export default function Type({ studyType, onClickStudyType }: any) {
+  console.log(studyType);
   return (
     <div className="w-full px-[1.4rem]">
       <section className="py-[2rem] ">
@@ -11,7 +12,11 @@ export default function Type() {
         </h1>
       </section>
       <section className="mt-[4rem] flex flex-col gap-[1.4rem]">
-        <MatchingContainer>
+        <MatchingContainer
+          onClick={() => {
+            onClickStudyType('온라인');
+          }}
+        >
           <div className="flex justify-between">
             <div>온라인 스터디</div>
             <div>
@@ -19,7 +24,11 @@ export default function Type() {
             </div>
           </div>
         </MatchingContainer>
-        <MatchingContainer>
+        <MatchingContainer
+          onClick={() => {
+            onClickStudyType('오프라인');
+          }}
+        >
           <div className="flex justify-between">
             <div>오프라인 스터디</div>
             <div>
@@ -27,7 +36,11 @@ export default function Type() {
             </div>
           </div>
         </MatchingContainer>
-        <MatchingContainer>
+        <MatchingContainer
+          onClick={() => {
+            onClickStudyType('상관없음');
+          }}
+        >
           <div className="flex justify-between">
             <div>온오프라인 스터디</div>
             <div>

--- a/src/app/(JH)/matching/_components/Type.tsx
+++ b/src/app/(JH)/matching/_components/Type.tsx
@@ -15,6 +15,7 @@ export default function Type({ studyType, onClickStudyType }: any) {
           onClick={() => {
             onClickStudyType('온라인');
           }}
+          active={studyType === '온라인' && true}
         >
           <div className="flex justify-between">
             <div>온라인 스터디</div>
@@ -27,6 +28,7 @@ export default function Type({ studyType, onClickStudyType }: any) {
           onClick={() => {
             onClickStudyType('오프라인');
           }}
+          active={studyType === '오프라인' && true}
         >
           <div className="flex justify-between">
             <div>오프라인 스터디</div>
@@ -39,6 +41,7 @@ export default function Type({ studyType, onClickStudyType }: any) {
           onClick={() => {
             onClickStudyType('상관없음');
           }}
+          active={studyType === '상관없음' && true}
         >
           <div className="flex justify-between">
             <div>온오프라인 스터디</div>

--- a/src/app/(suwan)/make-study-form/_component/StudyTeammateForm.tsx
+++ b/src/app/(suwan)/make-study-form/_component/StudyTeammateForm.tsx
@@ -13,7 +13,6 @@ export default function StudyTemmateForm() {
   const [isChecked, setChecked] = useState(false);
   const [studyMembers, setStudyMembers] = useState(1);
   const onClickStudyMembers = (type: string) => {
-    console.log(type);
     if (type == 'plus') {
       setStudyMembers((prev) => prev + 1);
     } else if (type == 'minus') {

--- a/src/components/(JH)/matching/MatchingContainer.tsx
+++ b/src/components/(JH)/matching/MatchingContainer.tsx
@@ -1,11 +1,16 @@
 export default function MatchingContainer({
   children,
+  onClick,
 }: {
   children: React.ReactNode;
+  onClick?: () => void;
 }) {
   {
     return (
-      <div className="w-full h-[6.4rem] rounded-[0.5rem] border-[0.1rem] border-gray-500 py-[2rem] px-[2.4rem] text-content-1">
+      <div
+        className="w-full h-[6.4rem] rounded-[0.5rem] border-[0.1rem] border-gray-500 py-[2rem] px-[2.4rem] text-content-1"
+        onClick={onClick}
+      >
         {children}
       </div>
     );

--- a/src/components/(JH)/matching/MatchingContainer.tsx
+++ b/src/components/(JH)/matching/MatchingContainer.tsx
@@ -1,18 +1,19 @@
 export default function MatchingContainer({
   children,
   onClick,
+  active,
 }: {
   children: React.ReactNode;
   onClick?: () => void;
+  active?: boolean;
 }) {
-  {
-    return (
-      <div
-        className="w-full h-[6.4rem] rounded-[0.5rem] border-[0.1rem] border-gray-500 py-[2rem] px-[2.4rem] text-content-1"
-        onClick={onClick}
-      >
-        {children}
-      </div>
-    );
-  }
+  let bg = active && 'bg-main-200 text-main-700';
+  return (
+    <div
+      className={`w-full h-[6.4rem] rounded-[0.5rem] border-[0.1rem] border-gray-500 py-[2rem] px-[2.4rem] text-content-1 ${bg}`}
+      onClick={onClick}
+    >
+      {children}
+    </div>
+  );
 }

--- a/src/components/(JH)/matching/MatchingFooter.tsx
+++ b/src/components/(JH)/matching/MatchingFooter.tsx
@@ -4,10 +4,12 @@ export default function MatchingFooter({
   step,
   Forward,
   Backward,
+  active,
 }: {
   step: number;
   Forward: () => void;
   Backward: () => void;
+  active?: boolean;
 }) {
   return (
     <footer className="flex justify-between w-full  px-[1.6rem] absolute bottom-[-10rem]  ">

--- a/src/components/(JH)/matching/SelectMatching.tsx
+++ b/src/components/(JH)/matching/SelectMatching.tsx
@@ -2,17 +2,20 @@ type TSelecMatchingProps = {
   children: React.ReactNode;
   type: 'interest' | 'mood';
   onClick?: () => void;
+  active?: boolean;
 };
 
 export default function SelectMatching({
   children,
   type = 'interest',
   onClick,
+  active,
 }: TSelecMatchingProps) {
   let size = type === 'interest' ? ' h-[9rem]' : 'h-[7rem]';
+  let bg = active && 'bg-main-200 text-main-700';
   return (
     <div
-      className={`min-w-[16.4rem] max-w-[27rem] w-5/12 ${size} border border-gray-300 flex items-center justify-center rounded-lg gap-2`}
+      className={`min-w-[16.4rem] max-w-[27rem] w-5/12 ${size} border border-gray-300 flex items-center justify-center rounded-lg gap-2 ${bg}`}
       onClick={onClick}
     >
       {children}

--- a/src/components/(JH)/matching/SelectMatching.tsx
+++ b/src/components/(JH)/matching/SelectMatching.tsx
@@ -1,16 +1,19 @@
 type TSelecMatchingProps = {
   children: React.ReactNode;
   type: 'interest' | 'mood';
+  onClick?: () => void;
 };
 
 export default function SelectMatching({
   children,
   type = 'interest',
+  onClick,
 }: TSelecMatchingProps) {
   let size = type === 'interest' ? ' h-[9rem]' : 'h-[7rem]';
   return (
     <div
       className={`min-w-[16.4rem] max-w-[27rem] w-5/12 ${size} border border-gray-300 flex items-center justify-center rounded-lg gap-2`}
+      onClick={onClick}
     >
       {children}
     </div>

--- a/src/components/(suwan)/my-study/common/Header.tsx
+++ b/src/components/(suwan)/my-study/common/Header.tsx
@@ -4,8 +4,8 @@ import TabLabel from '@/components/common/Tab/TabLabel';
 import { usePathname } from 'next/navigation';
 
 export default function Header() {
-  const pathname=usePathname()
-  console.log(pathname)
+  const pathname = usePathname();
+
   return (
     <>
       <SubHeader isWhite={true} />

--- a/src/components/common/Tab/CommonTab.tsx
+++ b/src/components/common/Tab/CommonTab.tsx
@@ -2,25 +2,11 @@
 import * as Tabs from '@radix-ui/react-tabs';
 import * as ScrollArea from '@radix-ui/react-scroll-area';
 import { area } from '@/constant/region';
-import { useState } from 'react';
 import TabLabel from './TabLabel';
 import { CiSearch } from 'react-icons/ci';
 import { IoSearch } from 'react-icons/io5';
 
-export default function CommonTab() {
-  const [selected, setSelected] = useState<string[]>([]);
-  const onSelectContent = (item: string) => {
-    let uniqueid: string = item;
-    if (selected.length >= 3) {
-      selected.shift();
-    }
-    setSelected([...selected, uniqueid]);
-  };
-
-  const onUnSelectContent = (item: string) => {
-    let filter = selected.filter((element) => element !== item);
-    setSelected(filter);
-  };
+export default function CommonTab({ regions, onClickRegion }: any) {
   return (
     <div className="flex flex-col gap-3 w-full, overflow-y-hidden">
       <>
@@ -71,7 +57,7 @@ export default function CommonTab() {
                     {area[key].map((item: any, index) => {
                       let newid: string = item;
 
-                      const bg = selected.includes(newid)
+                      const bg = regions.includes(newid)
                         ? 'bg-[#ECF1FF] text-[#4171FF]'
                         : 'bg-white';
                       return (
@@ -80,7 +66,7 @@ export default function CommonTab() {
                           key={index}
                           className={`${bg}  w-full h-[4.9rem] py-[1.4rem] ps-[2rem] border-b-[0.1rem] border-[#E4E4E4]`}
                           onClick={() => {
-                            onSelectContent(item);
+                            onClickRegion(item);
                           }}
                         >
                           <p className="w-[90%]">{item}</p>
@@ -102,12 +88,12 @@ export default function CommonTab() {
         </Tabs.List>
       </Tabs.Root>
       <div className="flex gap-4 p-4 flex-wrap m-auto">
-        {selected.map((item, index) => {
+        {regions.map((item: any, index: number) => {
           return (
             <TabLabel
               key={index}
               onUnSelectContent={() => {
-                onUnSelectContent(item);
+                onClickRegion(item);
               }}
             >
               {item}

--- a/src/lib/schemas/matching-schema.tsx
+++ b/src/lib/schemas/matching-schema.tsx
@@ -1,0 +1,11 @@
+import mongoose from 'mongoose';
+const matchingSchema = new mongoose.Schema({
+  userid: { type: String },
+  interests: { type: Array },
+  level: { type: Object },
+  studyType: { type: String },
+  preferRegion: { type: Array },
+  preferMood: { type: Array },
+});
+export const Matching =
+  mongoose.models?.Matching || mongoose.model('Matching', matchingSchema);

--- a/src/utils/matchingreducer.ts
+++ b/src/utils/matchingreducer.ts
@@ -26,6 +26,7 @@ export default function matchingreducer(state: Tmatching, action: TActionType) {
         };
       }
     }
+    //TODO:만약 이미선택된것이 한번더 선택된다면, 마찬가지로 취소가 되어야하는지?
     case 'setLevel': {
       return {
         ...state,
@@ -36,6 +37,13 @@ export default function matchingreducer(state: Tmatching, action: TActionType) {
       };
     }
     case 'setStudyType': {
+      let prev = state.studyType;
+      if (action.payload === prev) {
+        return {
+          ...state,
+          studyType: '',
+        };
+      }
       return {
         ...state,
         studyType: action.payload,

--- a/src/utils/matchingreducer.ts
+++ b/src/utils/matchingreducer.ts
@@ -1,0 +1,79 @@
+import { Tmatching } from '@/app/(JH)/matching/_components/ClientMatching';
+
+export type TActionType =
+  | { type: 'setInterest'; payload: string }
+  | { type: 'setLevel'; payload: { field: string; level: string } }
+  | { type: 'setStudyType'; payload: string }
+  | { type: 'setMood'; payload: string }
+  | { type: 'setRegion'; payload: string };
+
+export default function matchingreducer(state: Tmatching, action: TActionType) {
+  switch (action.type) {
+    case 'setInterest': {
+      const newInterests = [...state.interest];
+      if (newInterests.includes(action.payload)) {
+        return {
+          ...state,
+          interest: newInterests.filter((item) => item !== action.payload),
+        };
+      } else {
+        if (newInterests.length === 3) {
+          newInterests.shift();
+        }
+        return {
+          ...state,
+          interest: [...newInterests, action.payload],
+        };
+      }
+    }
+    case 'setLevel': {
+      return {
+        ...state,
+        level: {
+          ...state.level,
+          [action.payload.field]: action.payload.level,
+        },
+      };
+    }
+    case 'setStudyType': {
+      return {
+        ...state,
+        studyType: action.payload,
+      };
+    }
+    case 'setRegion': {
+      const newRegion = [...state.preferRegion];
+      if (newRegion.includes(action.payload)) {
+        return {
+          ...state,
+          preferRegion: newRegion.filter((item) => item !== action.payload),
+        };
+      } else {
+        if (newRegion.length === 3) {
+          newRegion.shift();
+        }
+        return {
+          ...state,
+          preferRegion: [...newRegion, action.payload],
+        };
+      }
+    }
+    case 'setMood': {
+      const newMood = [...state.preferMood];
+      if (newMood.includes(action.payload)) {
+        return {
+          ...state,
+          preferMood: newMood.filter((item) => item !== action.payload),
+        };
+      } else {
+        if (newMood.length === 3) {
+          newMood.shift();
+        }
+        return {
+          ...state,
+          preferMood: [...newMood, action.payload],
+        };
+      }
+    }
+  }
+}


### PR DESCRIPTION
### 🖼️ Screen shot
![bandicam-2024-07-01-23-04-02-206](https://github.com/Woongjin-Udemy-Pixe11/sturing/assets/124956289/f274d856-ffca-490a-9400-c30a9371bc8d) 

#### 데이터
![데이터확인](https://github.com/Woongjin-Udemy-Pixe11/sturing/assets/124956289/112e5de8-0e83-4b12-8a57-e4162e7570e9)


### 📝 Details

- 클라이언트 컴포넌트 상태를 통한, 데이터관리
- useState를 통한 관리에서 ->useReducer 로 리팩토링
- 각 매칭별 조건미충족시 하단 버튼 비활성화
- Reucer 파일을위한 utils 폴더생성

### 💬 Thinking

1. client 컴포넌트들중 중복렌더링이 살짝있어 4번씩 console.log 가찍혀 해당부분 memo 혹은 callback 을 활용해 최적화
2. footer 로빠진 다음단계 버튼 컴포넌트 조건 미충족시 스타일변화 추가
3. card 컴포넌트및 전체적인 매칭페이지 스타일 완료
