### PR TITLE
[fix] 마이페이지 스터디이력제외 완료.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -813,13 +813,13 @@
       "version": "15.7.12",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.12.tgz",
       "integrity": "sha512-5zvhXYtRNRluoE/jAp4GVsSduVUzNWKkOZrCDBWYtE7biZywwdC2AcEzg+cSMLFRfVgeAFqpfNabiPjxFddV1Q==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@types/react": {
       "version": "18.3.3",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.3.tgz",
       "integrity": "sha512-hti/R0pS0q1/xx+TsI73XIqk26eBsISZ2R0wUijXIngRK9R/e7Xw/cXVxQK7R5JjW+SV4zGcn5hXjudkN/pLIw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -829,7 +829,7 @@
       "version": "18.3.0",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.0.tgz",
       "integrity": "sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@types/react": "*"
       }
@@ -1535,7 +1535,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",

--- a/src/app/(JH)/users/[userid]/_pages/MyPage.tsx
+++ b/src/app/(JH)/users/[userid]/_pages/MyPage.tsx
@@ -17,10 +17,10 @@ export default async function MyPage({
       cache: 'no-store',
     })
   ).json();
-  console.log(data);
   if (data === null) {
     return '아직 유저가 없습니다.';
   }
+  console.log(data);
 
   //TODO: 404 페이지 혹은 유저없음 페이지 만들기
 
@@ -36,7 +36,6 @@ export default async function MyPage({
         )}
       </section>
       <SturingRate data={data} />
-      {/* //TODO:스터디 리뷰 스키마 */}
       <SectionNavigator
         title={`받은 스터디 평가 ${data.numberReview ? data.numberReview : 0}`}
         moveLink={`/users/${userid}/mystudyreview`}
@@ -47,7 +46,6 @@ export default async function MyPage({
           moveLink={`/users/${userid}/mystudylog`}
         />
       )}
-      {/* //Section Navigator 에 옆에 숫자 추가가능하도록하면 좋을거같음. */}
     </main>
   );
 }

--- a/src/app/(JH)/users/[userid]/_pages/MyPage.tsx
+++ b/src/app/(JH)/users/[userid]/_pages/MyPage.tsx
@@ -38,7 +38,7 @@ export default async function MyPage({
       <SturingRate data={data} />
       {/* //TODO:스터디 리뷰 스키마 */}
       <SectionNavigator
-        title="받은 스터디 평가 20"
+        title={`받은 스터디 평가 ${data.numberReview ? data.numberReview : 0}`}
         moveLink={`/users/${userid}/mystudyreview`}
       />
       {!auth && (

--- a/src/app/(JH)/users/[userid]/_pages/MyPageDetail.tsx
+++ b/src/app/(JH)/users/[userid]/_pages/MyPageDetail.tsx
@@ -33,7 +33,14 @@ export default function MyPageDetail({
         </div>
       </div>
       <UserDetailInfo data={data} />
-      <UserMatchingInfo data={data} />
+      {data.matchingInfo ? (
+        <UserMatchingInfo data={data} />
+      ) : (
+        <section className='mt-10'>
+          <div>아직 매칭정보가 없습니다.</div>
+          <h1>함께 매칭을 하러가요!</h1>
+        </section>
+      )}
     </main>
   );
 }

--- a/src/app/(JH)/users/[userid]/_pages/MyPageDetail.tsx
+++ b/src/app/(JH)/users/[userid]/_pages/MyPageDetail.tsx
@@ -33,10 +33,10 @@ export default function MyPageDetail({
         </div>
       </div>
       <UserDetailInfo data={data} />
-      {data.matchingInfo ? (
+      {data.matchinginfo ? (
         <UserMatchingInfo data={data} />
       ) : (
-        <section className='mt-10'>
+        <section className="mt-10">
           <div>아직 매칭정보가 없습니다.</div>
           <h1>함께 매칭을 하러가요!</h1>
         </section>

--- a/src/app/(JH)/users/[userid]/_pages/MyStudyReviewList.tsx
+++ b/src/app/(JH)/users/[userid]/_pages/MyStudyReviewList.tsx
@@ -8,9 +8,10 @@ export default async function MyStudyReviewList({ data }: { data: any }) {
       <MyPageHeader>받은 스터디 평가</MyPageHeader>
       <div className="mt-[2rem]">후기 {data.length}개</div>
       <div className="flex flex-col gap-[2rem] mt-[2rem] ">
-        {data.map((review: any) => {
-          return <StudyReviewCard key={review._id} review={review} />;
-        })}
+        {data &&
+          data.map((review: any) => {
+            return <StudyReviewCard key={review._id} review={review} />;
+          })}
       </div>
     </main>
   );

--- a/src/app/(JH)/users/[userid]/mystudyreview/page.tsx
+++ b/src/app/(JH)/users/[userid]/mystudyreview/page.tsx
@@ -1,4 +1,3 @@
-import { getSession } from '@/utils/getSessions';
 import MyStudyReviewList from '../_pages/MyStudyReviewList';
 
 export default async function Page({ params }: { params: any }) {

--- a/src/app/(JH)/users/[userid]/mystudyreview/page.tsx
+++ b/src/app/(JH)/users/[userid]/mystudyreview/page.tsx
@@ -1,9 +1,8 @@
 import { getSession } from '@/utils/getSessions';
 import MyStudyReviewList from '../_pages/MyStudyReviewList';
 
-export default async function Page() {
-  const session = await getSession();
-  const id = session?.user?.id;
+export default async function Page({ params }: { params: any }) {
+  const id = params.userid;
   const data = await (
     await fetch(`http://localhost:3000/api/study-review?id=${id}`)
   ).json();

--- a/src/app/api/mypage/route.ts
+++ b/src/app/api/mypage/route.ts
@@ -1,5 +1,6 @@
 import connectDB from '@/lib/db';
 import { Matching } from '@/lib/schemas/matchingSchema';
+import { StudyReview } from '@/lib/schemas/studyReviewSchema';
 import { User } from '@/lib/schemas/userSchema';
 import { revalidatePath } from 'next/cache';
 
@@ -13,13 +14,17 @@ export async function GET(req: Request) {
 
     let users = await User.findOne({ _id: `${id}` });
     let matchinginfo = await Matching.findOne({ userid: `${id}` });
+    let reviewList = await StudyReview.find({
+      evaluateduser: `${id}`,
+    });
+    let numberReview = reviewList.length;
 
     if (users === null || matchinginfo === null) {
       return null;
     }
     revalidatePath(`/users/${id}/detail`);
 
-    return new Response(JSON.stringify({ users, matchinginfo }), {
+    return new Response(JSON.stringify({ users, matchinginfo, numberReview }), {
       status: 200,
       headers: { 'Content-Type': 'application/json' },
     });

--- a/src/app/api/mypage/route.ts
+++ b/src/app/api/mypage/route.ts
@@ -19,11 +19,6 @@ export async function GET(req: Request) {
     });
     let numberReview = reviewList.length;
 
-    if (users === null || matchinginfo === null) {
-      return null;
-    }
-    revalidatePath(`/users/${id}/detail`);
-
     return new Response(JSON.stringify({ users, matchinginfo, numberReview }), {
       status: 200,
       headers: { 'Content-Type': 'application/json' },

--- a/src/app/api/study-review/route.ts
+++ b/src/app/api/study-review/route.ts
@@ -1,5 +1,6 @@
 import connectDB from '@/lib/db';
 import { StudyReview } from '@/lib/schemas/studyReviewSchema';
+import { User } from '@/lib/schemas/userSchema';
 import mongoose from 'mongoose';
 
 export async function GET(request: Request) {
@@ -12,7 +13,8 @@ export async function GET(request: Request) {
 
     let reviewList = await StudyReview.find({
       evaluateduser: `${id}`,
-    });
+    }).populate({ path: 'userId', select: 'nickname image' });
+    console.log(reviewList);
     if (reviewList === null) {
       return null;
     }

--- a/src/components/(JH)/users/MyPageProfileCard.tsx
+++ b/src/components/(JH)/users/MyPageProfileCard.tsx
@@ -18,7 +18,7 @@ export default async function MyPageProfileCard({
           <h1 className="font-bold text-headline-3">{data.users.nickname}</h1>
           {auth && <h2>{'>'}</h2>}
         </div>
-        {data.matchingInfo && (
+        {data.matchinginfo && (
           <>
             <h3 className="text-content-2">
               {data.matchinginfo.level[`${data.matchinginfo.interests[0]}`]}

--- a/src/components/(JH)/users/MyPageProfileCard.tsx
+++ b/src/components/(JH)/users/MyPageProfileCard.tsx
@@ -18,14 +18,20 @@ export default async function MyPageProfileCard({
           <h1 className="font-bold text-headline-3">{data.users.nickname}</h1>
           {auth && <h2>{'>'}</h2>}
         </div>
-        <h3 className="text-content-2">
-          {data.matchinginfo.level[`${data.matchinginfo.interests[0]}`]}
-        </h3>
-        <div className="flex gap-2 mt-2">
-          <MyPageLabel content={`🌏 ${data.matchinginfo.preferRegion[0]}`} />
-          <MyPageLabel content={`${data.matchinginfo.interests[0]}`} />
-          <MyPageLabel content={`${data.matchinginfo.preferMood[0]}`} />
-        </div>
+        {data.matchingInfo && (
+          <>
+            <h3 className="text-content-2">
+              {data.matchinginfo.level[`${data.matchinginfo.interests[0]}`]}
+            </h3>
+            <div className="flex gap-2 mt-2">
+              <MyPageLabel
+                content={`🌏 ${data.matchinginfo.preferRegion[0]}`}
+              />
+              <MyPageLabel content={`${data.matchinginfo.interests[0]}`} />
+              <MyPageLabel content={`${data.matchinginfo.preferMood[0]}`} />
+            </div>
+          </>
+        )}
       </div>
     </section>
   );

--- a/src/components/(JH)/users/MypageHeader.tsx
+++ b/src/components/(JH)/users/MypageHeader.tsx
@@ -1,3 +1,5 @@
+'use client';
+import { useRouter } from 'next/navigation';
 import { GoChevronLeft } from 'react-icons/go';
 
 export default function MyPageHeader({
@@ -5,9 +7,10 @@ export default function MyPageHeader({
 }: {
   children?: React.ReactNode;
 }) {
+  const router = useRouter();
   return (
     <header className="flex text-center  border-b-2 border-gray-300">
-      <GoChevronLeft size={24} className="mb-4" />
+      <GoChevronLeft size={24} className="mb-4" onClick={() => router.back()} />
       {children && <h1 className="flex-1">{children}</h1>}
     </header>
   );

--- a/src/components/(JH)/users/StudyReviewCard.tsx
+++ b/src/components/(JH)/users/StudyReviewCard.tsx
@@ -4,10 +4,10 @@ export default function StudyReviewCard({ review }: any) {
   return (
     <section className="flex gap-[0.8rem]  border-b-2 border-gray-400 pb-[2rem] w-[90%]">
       <div className="w-[3.5rem] h-[3.5rem] border border-gray-500 rounded-full">
-        <img src="/images/user-card-dummy.png" className="object-fill"></img>
+        <img src={`${review.userId.image}`} className="object-fill"></img>
       </div>
       <div className="w-[29.7rem] flex flex-col gap-4">
-        <h1 className="font-bold">취뽀기원</h1>
+        <h1 className="font-bold">{review.userId.nickname}</h1>
         <p>{review.studyReviewContent}</p>
       </div>
     </section>

--- a/src/components/(JH)/users/SturingRate.tsx
+++ b/src/components/(JH)/users/SturingRate.tsx
@@ -7,15 +7,18 @@ export default async function SturingRate({ data }: any) {
       {/* TODO://위치 이동시키기 퍼센트따라서 */}
       <section>
         <article className="border-[0.1rem] border-gray-300 px-[2.4rem] py-[3.9rem] rounded-md">
-          <div className="relative flex items-center justify-center w-[5.6rem] h-[3rem] bg-blue-500 text-white text-2xl rounded-[10rem] mb-2 m-auto left-12">
-            <span>{data.users.sturingPercent}%</span>
-            <div className="absolute bottom-0 left-1/2 transform -translate-x-1/2 translate-y-1/2 w-2 h-2 bg-blue-500 rotate-45"></div>
-          </div>
           <div className="w-full bg-gray-400 rounded-full h-[0.8rem] ">
             <div
-              className="bg-gradient-to-r from-[#FFE4E0] to-[#3A6CFF] h-[0.8rem] rounded-full"
-              style={{ width: `${data.users.sturingPercent}` }}
-            ></div>
+              className="relative bg-gradient-to-r from-[#FFE4E0] to-[#3A6CFF] h-[0.8rem] rounded-full"
+              style={{ width: `${data.users.sturingPercent}%` }}
+            >
+              <div className="absolute top-[-3.5rem] right-[-3rem]  w-[5.6rem] h-[3rem]">
+                <div className="relative flex items-center justify-center w-[5.6rem] h-[3rem] bg-blue-500 text-white text-2xl rounded-[10rem] mb-2 m-auto ">
+                  <span>{data.users.sturingPercent}%</span>
+                  <div className="absolute bottom-0 left-1/2 transform -translate-x-1/2 translate-y-1/2 w-2 h-2 bg-blue-500 rotate-45"></div>
+                </div>
+              </div>
+            </div>
           </div>
           <div className="w-[0.6rem] h-[0.6rem] bg-gray-600 rounded-full m-auto mt-[0.65rem]"></div>
           <p className="text-content-2 text-center text-gray-600">


### PR DESCRIPTION
### 🖼️ Screen shot

| 완성 이미지/GIF |
| :-------------: |
| ![image](https://github.com/Woongjin-Udemy-Pixe11/sturing/assets/124956289/731c9328-0510-4030-a981-7ca951261ce6) |

### 📝 Details

- 마이페이지 매칭정보없을시 매칭정보 안보여주는쪽으로 수정
- 스터링지수 퍼센테이지따라 말풍선 이동 (스타일 수정)
- 북마크, 스터디 리뷰(유저정보 및 이미지 연동완료)
- 뒤로가기 UseClient Router back처리

### 💬 Thinking

1. 스터디 이력 부분 완성되면 추가하겠습니다.
2. 회원탈퇴시 DB삭제 범위 정해지면 구현하겠습니다.
