### PR TITLE
[feat] 회원탈퇴 및 로그아웃 모달 

### DIFF
--- a/src/app/(JH)/users/[userid]/_pages/MyPageDetail.tsx
+++ b/src/app/(JH)/users/[userid]/_pages/MyPageDetail.tsx
@@ -2,6 +2,7 @@ import MyPageHeader from '@/components/(JH)/users/MypageHeader';
 import UserDetailInfo from '@/components/(JH)/users/UserDetailInfo';
 import { FaCamera } from 'react-icons/fa';
 import UserMatchingInfo from '@/components/(JH)/users/UserMatchingInfo';
+import { logout } from '@/lib/actions/userAction';
 
 export default function MyPageDetail({
   auth,
@@ -41,6 +42,12 @@ export default function MyPageDetail({
           <h1>함께 매칭을 하러가요!</h1>
         </section>
       )}
+      <section className="flex justify-center gap-5">
+        <form>
+          <button formAction={logout}>로그아웃</button>
+        </form>
+        <div>회원탈퇴</div>
+      </section>
     </main>
   );
 }

--- a/src/app/(JH)/users/[userid]/_pages/MyPageDetail.tsx
+++ b/src/app/(JH)/users/[userid]/_pages/MyPageDetail.tsx
@@ -3,6 +3,7 @@ import UserDetailInfo from '@/components/(JH)/users/UserDetailInfo';
 import { FaCamera } from 'react-icons/fa';
 import UserMatchingInfo from '@/components/(JH)/users/UserMatchingInfo';
 import { logout } from '@/lib/actions/userAction';
+import Link from 'next/link';
 
 export default function MyPageDetail({
   auth,
@@ -14,7 +15,7 @@ export default function MyPageDetail({
   if (!auth) {
     return;
   }
-  // console.log(data, '🟢');
+  console.log(data, '🟢');
 
   return (
     <main>
@@ -46,7 +47,7 @@ export default function MyPageDetail({
         <form>
           <button formAction={logout}>로그아웃</button>
         </form>
-        <div>회원탈퇴</div>
+        <Link href={`/users/${data.users._id}/detail/delete`}>회원탈퇴</Link>
       </section>
     </main>
   );

--- a/src/app/(JH)/users/[userid]/detail/delete/page.tsx
+++ b/src/app/(JH)/users/[userid]/detail/delete/page.tsx
@@ -1,0 +1,54 @@
+'use client';
+import MyPageHeader from '@/components/(JH)/users/MypageHeader';
+import LongButton from '@/components/common/LongButton';
+import { signOut } from 'next-auth/react';
+
+export default async function page({ params }: { params: any }) {
+  const id = params.userid;
+  const deleteUser = async (id: string) => {
+    try {
+      const response = await fetch('/api/mypage', {
+        method: 'DELETE',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(id),
+      });
+      if (!response.ok) {
+        throw new Error('HTTP error!');
+      }
+      const result = await response.json();
+      await signOut();
+      console.log('Server Response', result);
+    } catch (error) {
+      console.log(error);
+    }
+  };
+
+  return (
+    <main>
+      <MyPageHeader>회원 탈퇴</MyPageHeader>
+      <section className="text-headline-2 font-bold px-[1.6rem] py-[3.1rem]">
+        <h1>정말 탈퇴하시겠어요?</h1>
+        <h1>탈퇴하기 전에 확인해주세요!</h1>
+      </section>
+      <section className="px-[1.6rem] py-[2.4rem]">
+        <ul className="list-disc text-gray-800 body-1 flex flex-col gap-3">
+          <li>진행중,종료,대기중인 모든 스터디가 사라집니다.</li>
+          <li>모든 스터디에서 팀원 OOO님이 사라집니다.</li>
+          <li>작성하신 모든 글(게시물,댓글,투두리스트)등이 전부 삭제됩니다.</li>
+          <li>모든 이용내역은 삭제되며 복원이 불가능 합니다.</li>
+          <li>계정이 삭제되면 복원이 불가능 합니다.</li>
+        </ul>
+      </section>
+      <LongButton
+        color="gray"
+        onClick={() => {
+          deleteUser(id);
+        }}
+      >
+        회원 탈퇴하기
+      </LongButton>
+    </main>
+  );
+}

--- a/src/app/(JH)/users/[userid]/detail/delete/page.tsx
+++ b/src/app/(JH)/users/[userid]/detail/delete/page.tsx
@@ -1,32 +1,22 @@
 'use client';
+import DelteUserModal from '@/components/(JH)/users/DeleteModal';
 import MyPageHeader from '@/components/(JH)/users/MypageHeader';
 import LongButton from '@/components/common/LongButton';
-import { signOut } from 'next-auth/react';
+import { useState } from 'react';
 
-export default async function page({ params }: { params: any }) {
+export default function page({ params }: { params: any }) {
+  const [isOpen, setIsOpen] = useState(false);
   const id = params.userid;
-  const deleteUser = async (id: string) => {
-    try {
-      const response = await fetch('/api/mypage', {
-        method: 'DELETE',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify(id),
-      });
-      if (!response.ok) {
-        throw new Error('HTTP error!');
-      }
-      const result = await response.json();
-      await signOut();
-      console.log('Server Response', result);
-    } catch (error) {
-      console.log(error);
-    }
-  };
 
   return (
     <main>
+      <DelteUserModal
+        id={id}
+        show={isOpen}
+        onClose={() => {
+          setIsOpen(false);
+        }}
+      />
       <MyPageHeader>회원 탈퇴</MyPageHeader>
       <section className="text-headline-2 font-bold px-[1.6rem] py-[3.1rem]">
         <h1>정말 탈퇴하시겠어요?</h1>
@@ -41,10 +31,11 @@ export default async function page({ params }: { params: any }) {
           <li>계정이 삭제되면 복원이 불가능 합니다.</li>
         </ul>
       </section>
+
       <LongButton
         color="gray"
         onClick={() => {
-          deleteUser(id);
+          setIsOpen(true);
         }}
       >
         회원 탈퇴하기

--- a/src/app/api/mypage/route.ts
+++ b/src/app/api/mypage/route.ts
@@ -1,6 +1,7 @@
 import connectDB from '@/lib/db';
 import { Matching } from '@/lib/schemas/matchingSchema';
 import { StudyReview } from '@/lib/schemas/studyReviewSchema';
+import { Study } from '@/lib/schemas/studySchema';
 import { User } from '@/lib/schemas/userSchema';
 import { revalidatePath } from 'next/cache';
 
@@ -44,4 +45,14 @@ export async function PATCH(request: Request) {
   revalidatePath(`/users/${id}/detail`);
 
   return new Response(JSON.stringify({ updatematching }));
+}
+
+export async function DELETE(request: Request) {
+  await connectDB();
+
+  const res = await request.json();
+  let test = await User.deleteOne({ _id: res });
+  await Matching.deleteOne({ userid: res });
+  await Study.deleteMany({ leaderId: res });
+  return new Response(JSON.stringify({ test }));
 }

--- a/src/components/(JH)/users/DeleteModal.tsx
+++ b/src/components/(JH)/users/DeleteModal.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { signOut } from 'next-auth/react';
+
+export function DelteUserModal({
+  id,
+  show,
+  onClose,
+}: {
+  id: any;
+  show: any;
+  onClose: any;
+}) {
+  if (!show) return null;
+  const deleteUser = async (id: string) => {
+    try {
+      const response = await fetch('/api/mypage', {
+        method: 'DELETE',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(id),
+      });
+      if (!response.ok) {
+        throw new Error('HTTP error!');
+      }
+      const result = await response.json();
+      await signOut();
+      console.log('Server Response', result);
+    } catch (error) {
+      console.log(error);
+    }
+  };
+  console.log(id);
+
+  return (
+    <div className="fixed backdrop-blur-sm w-screen h-screen">
+      <section className="fixed  left-0 right-0 mx-auto w-[40rem] top-[30%] h-[20rem] bg-white border-gray-200 border rounded-md text-center p-10 py-[5rem]">
+        <h1 className="text-headline-2 font-bold">정말 탈퇴하시겠습니까?</h1>
+        <div className="flex gap-3 justify-center py-[2rem]">
+          <button
+            className="border border-blue-500 bg-blue-500 text-white w-[4.5rem] h-[4rem] rounded-[4px]"
+            onClick={() => {
+              deleteUser(id);
+            }}
+          >
+            예
+          </button>
+          <button
+            className="border border-blue-500 bg-white text-blue-500 w-[7.5rem] h-[4rem] rounded-[4px]"
+            onClick={onClose}
+          >
+            아니오
+          </button>
+        </div>
+      </section>
+    </div>
+  );
+}
+
+export default DelteUserModal;

--- a/src/components/(JH)/users/DeleteModal.tsx
+++ b/src/components/(JH)/users/DeleteModal.tsx
@@ -31,10 +31,10 @@ export function DelteUserModal({
       console.log(error);
     }
   };
-  console.log(id);
 
   return (
-    <div className="fixed backdrop-blur-sm w-screen h-screen">
+    // "fixed inset-0 bg-black bg-opacity-50 z-40" inset-0
+    <div className="fixed inset-0 backdrop-blur-sm ">
       <section className="fixed  left-0 right-0 mx-auto w-[40rem] top-[30%] h-[20rem] bg-white border-gray-200 border rounded-md text-center p-10 py-[5rem]">
         <h1 className="text-headline-2 font-bold">정말 탈퇴하시겠습니까?</h1>
         <div className="flex gap-3 justify-center py-[2rem]">

--- a/src/lib/actions/userAction.ts
+++ b/src/lib/actions/userAction.ts
@@ -9,5 +9,5 @@ export async function GithubLogin() {
 
 export async function logout() {
   await signOut();
-  //redirect('/');
+  redirect('/');
 }


### PR DESCRIPTION
### 🖼️ Screen shot

| 완성 이미지/GIF |
| :-------------: |
| ![image](https://github.com/Woongjin-Udemy-Pixe11/sturing/assets/124956289/2f084d1f-6df8-442f-b7db-a01c100d4225) |

### 📝 Details

- 로그아웃시 홈으로이동(logOut 코드에서 redirect ('/') 주석처리 풀었습니다.
- 탈퇴시 (유저정보,매칭정보,유저가개설한 스터디정보 삭제)

### 💬 Thinking

1. 추후 협의후 삭제범위늘리겠습니다.
