### PR TITLE
[feat] 스터디 검색기능 탭바와 연동(전체/스터디)

### DIFF
--- a/src/app/(ryukyung)/pages/SearchPart.tsx
+++ b/src/app/(ryukyung)/pages/SearchPart.tsx
@@ -3,8 +3,10 @@ import SearchInput from '@/components/common/SearchInput';
 import CurrentSearch from '@/components/search/CurrentSearch';
 import useLocalStorage from '@/utils/useLocalStorage';
 import { useState, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
 
 export default function SearchPart() {
+  const router = useRouter();
   const [inputValue, setInputValue] = useState('');
   const [recentSearches, addSearchToLocalStorage, removeFromLocal] =
     useLocalStorage('recent', []);
@@ -17,11 +19,13 @@ export default function SearchPart() {
   const onSearch = () => {
     if (recentSearches.includes(inputValue)) {
       setInputValue('');
+      router.push(`/search/result?keyword=${inputValue}`);
       return;
     }
     if (inputValue.trim() != '') {
       addSearchToLocalStorage(inputValue);
       setInputValue('');
+      router.push(`/search/result?keyword=${inputValue}`);
     }
   };
 

--- a/src/app/(ryukyung)/search/result/page.tsx
+++ b/src/app/(ryukyung)/search/result/page.tsx
@@ -12,7 +12,14 @@ const tabList = [
   { name: '강의', component: <TabLecture />, isLecture: true },
 ];
 
-export default function page() {
+export default async function page({ searchParams }: { searchParams: any }) {
+  const keyword = searchParams.keyword;
+  const data = await (
+    await fetch(`http://localhost:3000/api/search?keyword=${keyword}`, {
+      cache: 'no-store',
+    })
+  ).json();
+  console.log(data.searchstudies);
   return (
     <>
       <header className="w-full px-[1.6rem] flex justify-between items-center gap-[.8rem] py-[1.2rem]">

--- a/src/app/(ryukyung)/search/result/page.tsx
+++ b/src/app/(ryukyung)/search/result/page.tsx
@@ -6,12 +6,6 @@ import { IoSearch } from 'react-icons/io5';
 import TabBarBlue from '@/components/search/TabBarBlue';
 import Footer from '@/components/common/Footer';
 
-const tabList = [
-  { name: '전체', component: <TabAll />, isLecture: false },
-  { name: '스터디', component: <TabStudy />, isLecture: false },
-  { name: '강의', component: <TabLecture />, isLecture: true },
-];
-
 export default async function page({ searchParams }: { searchParams: any }) {
   const keyword = searchParams.keyword;
   const data = await (
@@ -19,7 +13,16 @@ export default async function page({ searchParams }: { searchParams: any }) {
       cache: 'no-store',
     })
   ).json();
-  console.log(data.searchstudies);
+  let searchstudy = data.searchstudies;
+  const tabList = [
+    { name: '전체', component: <TabAll data={searchstudy} />, isLecture: false },
+    {
+      name: '스터디',
+      component: <TabStudy data={searchstudy} />,
+      isLecture: false,
+    },
+    { name: '강의', component: <TabLecture />, isLecture: true },
+  ];
   return (
     <>
       <header className="w-full px-[1.6rem] flex justify-between items-center gap-[.8rem] py-[1.2rem]">

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -1,0 +1,22 @@
+import connectDB from '@/lib/db';
+import { Study } from '@/lib/schemas/studySchema';
+//TODO: 강의검색쿼리집어넣어야함
+export async function GET(req: Request) {
+  connectDB();
+  try {
+    const url = new URL(req.url);
+    const keyword = url.searchParams.get('keyword');
+    console.log(keyword);
+    const searchstudies = await Study.find({
+      studyName: {
+        $regex: new RegExp(`${keyword}`, 'i'),
+      },
+    });
+    return new Response(JSON.stringify({ searchstudies }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (error) {
+    console.log(error);
+  }
+}

--- a/src/components/search/StudyList.tsx
+++ b/src/components/search/StudyList.tsx
@@ -4,10 +4,11 @@ import GrayFullLink from './GrayFullLink';
 
 type TStudyListProps = {
   isDetail?: boolean;
+  data?: any;
 };
 
-export default function StudyList(props: TStudyListProps) {
-  const { isDetail } = props;
+export default async function StudyList(props: TStudyListProps) {
+  const { isDetail,data } = props;
   let isFull = false;
   let cardList = dummyCardList;
 
@@ -25,8 +26,8 @@ export default function StudyList(props: TStudyListProps) {
           </span>
         )}
         <ul className="w-full grid grid-cols-2 justify-stretch items-center flex-wrap gap-x-[1.6rem] gap-y-[.8rem] py-[2rem]">
-          {cardList &&
-            cardList.map((card) => (
+          {data &&
+            data.map((card:any) => (
               <li key={card.id}>
                 <Card
                   studyImage={card.studyImage}

--- a/src/components/search/TabAll.tsx
+++ b/src/components/search/TabAll.tsx
@@ -1,10 +1,10 @@
 import LectureList from './LectureList';
 import StudyList from './StudyList';
 
-export default function TabAll() {
+export default function TabAll({ data }: { data: any }) {
   return (
     <>
-      <StudyList />
+      <StudyList data={data} />
       <hr className="w-full h-[.6rem] bg-gray-200 my-[2rem] border-0" />
       <LectureList />
     </>

--- a/src/components/search/TabStudy.tsx
+++ b/src/components/search/TabStudy.tsx
@@ -1,9 +1,9 @@
 import StudyList from './StudyList';
 
-export default function TabStudy() {
+export default async function TabStudy({ data }: { data: any }) {
   return (
     <>
-      <StudyList isDetail={true} />
+      <StudyList isDetail={true} data={data} />
     </>
   );
 }


### PR DESCRIPTION
### 🖼️ Screen shot

| 완성 이미지/GIF |
| :-------------: |
|![bandicam-2024-07-10-14-53-27-785](https://github.com/Woongjin-Udemy-Pixe11/sturing/assets/124956289/2ffa378e-4943-49ec-8d25-c354863a5d58)  |



### 📝 Details

- 키워드검색 라우트함수 작성 (스터디만있음, 강의는 미구현)
- 전체 탭, 스터디 탭은 mongDB 데이터 연동
- 강의는 연동안됨

### 💬 Thinking

1. 강의연동 및 상세페이지
2. 키워드 클릭시 키워드검색으로이동 추후 구현
