### PR TITLE
[design] 검색 필터 css 수정

### DIFF
--- a/src/components/(suwan)/my-study/calendar/CalendarContainer.tsx
+++ b/src/components/(suwan)/my-study/calendar/CalendarContainer.tsx
@@ -3,7 +3,7 @@ import Schedule from './Schedule';
 
 export default function CalendarContainer() {
   return (
-    <div className="bg-gray-100 p-[2rem]">
+    <div className="bg-gray-100 p-[2.5rem]">
       <Calendar />
       <Schedule />
     </div>

--- a/src/components/common/Tab/CommonTab.tsx
+++ b/src/components/common/Tab/CommonTab.tsx
@@ -1,10 +1,9 @@
 'use client';
-import * as Tabs from '@radix-ui/react-tabs';
-import * as ScrollArea from '@radix-ui/react-scroll-area';
 import { area } from '@/constant/region';
-import TabLabel from './TabLabel';
-import { CiSearch } from 'react-icons/ci';
+import * as ScrollArea from '@radix-ui/react-scroll-area';
+import * as Tabs from '@radix-ui/react-tabs';
 import { IoSearch } from 'react-icons/io5';
+import TabLabel from './TabLabel';
 
 export default function CommonTab({ regions, onClickRegion }: any) {
   return (

--- a/src/components/common/calender/RangeCalendar.tsx
+++ b/src/components/common/calender/RangeCalendar.tsx
@@ -2,8 +2,8 @@
 
 import * as React from 'react';
 
-import { DateRange } from 'react-day-picker';
 import { addDays, format } from 'date-fns';
+import { DateRange } from 'react-day-picker';
 import { Calendar } from './ui/calendar';
 
 type TRangeCalendarProps = {
@@ -24,8 +24,8 @@ export default function RangeCalendar(props: TRangeCalendarProps) {
   }, [date]);
 
   return (
-    <>
-      <span className="text-body-1 text-main-600">
+    <div className="flex flex-col">
+      <span className="text-body-2 items-start text-main-600">
         {date?.from ? (
           date.to ? (
             <>
@@ -38,14 +38,16 @@ export default function RangeCalendar(props: TRangeCalendarProps) {
           <span>Pick a date</span>
         )}
       </span>
-      <Calendar
-        initialFocus
-        mode="range"
-        defaultMonth={date?.from}
-        selected={date}
-        onSelect={setDate}
-        numberOfMonths={1}
-      />
-    </>
+      <div className="flex justify-center w-full">
+        <Calendar
+          initialFocus
+          mode="range"
+          defaultMonth={date?.from}
+          selected={date}
+          onSelect={setDate}
+          numberOfMonths={1}
+        />
+      </div>
+    </div>
   );
 }

--- a/src/components/common/calender/ui/calendar.tsx
+++ b/src/components/common/calender/ui/calendar.tsx
@@ -20,7 +20,7 @@ function Calendar({
         months: 'flex flex-col sm:flex-row space-y-4 sm:space-x-4 sm:space-y-0',
         month: 'space-y-4',
         caption:
-          'flex justify-center relative items-center pb-[1.5rem] border-gray-300 border-b',
+          'flex justify-center relative items-center py-[1.5rem] border-gray-300 border-b',
         caption_label: 'text-[1.6rem] font-semibold',
         nav: 'space-x-1 flex items-center ',
         nav_button:
@@ -34,9 +34,9 @@ function Calendar({
         head_row: 'flex gap-[1.6rem]',
         head_cell:
           'hidden text-muted-foreground rounded-full font-normal text-content-1 h-[3rem] w-[3rem]',
-        row: 'flex w-full justify-center gap-[1rem] py-[.8rem]',
+        row: 'flex w-full justify-center gap-[1.2rem] py-[.8rem]',
         cell: 'flex w-full justify-centerp-3 text-center text-content-1 relative [&:has([aria-selected].day-range-end)]:rounded-r-full [&:has([aria-selected].day-range-start)]:rounded-l-full [&:has([aria-selected].day-outside)]:bg-accent/50 first:text-red last:text-main-700 first:[&:has([aria-selected])]:rounded-l-full last:[&:has([aria-selected])]:rounded-r-full focus-within:relative focus-within:z-20',
-        day: 'h-[calc((100vw-15rem)/7)] w-[calc((100vw-15rem)/7)] font-normal rounded-full',
+        day: 'h-[calc((100vw-16rem)/7)] w-[calc((100vw-16rem)/7)] max-w-[5rem] max-h-[5rem] aspect-ratio font-normal rounded-full',
 
         day_range_end: 'day-range-end',
         day_range_start: 'day-range-start',

--- a/src/components/search/BottomSheetFilter.tsx
+++ b/src/components/search/BottomSheetFilter.tsx
@@ -1,10 +1,12 @@
+import { GrPowerReset } from 'react-icons/gr';
 import TabBarUnderBlue from './TabBarUnderBlue';
 import Field from './filter/Field';
 import Level from './filter/Level';
 import People from './filter/People';
 import Period from './filter/Period';
 import Region from './filter/Region';
-import { GrPowerReset } from 'react-icons/gr';
+
+type TBottomSheetFilter = { onClose?: () => void };
 
 const tabList = [
   { name: '분야', component: <Field /> },
@@ -14,11 +16,16 @@ const tabList = [
   { name: '수준', component: <Level /> },
 ];
 
-export default function BottomSheetFilter() {
+export default function BottomSheetFilter({ onClose }: TBottomSheetFilter) {
   return (
-    <div className="w-full rounded-t-[1rem] border border-gray-300 shadow-modal bg-white h-[75vh]">
-      <span className="block mx-[1.6rem] my-[2.8rem] text-[1.8rem]">필터</span>
-      <TabBarUnderBlue tabList={tabList} />
+    <div className="w-full flex flex-col justify-between rounded-t-[1rem] border border-gray-300 shadow-modal bg-white h-[75vh] ">
+      <span className="block mx-[1.6rem] mt-[2.0rem] mb-[1.2rem] text-[1.8rem]">
+        필터
+      </span>
+      <div className="flex-1 overflow-hidden">
+        <TabBarUnderBlue tabList={tabList} />
+      </div>
+
       <div className=" w-full flex justify-center gap-[.8rem] pb-[1.8rem]">
         <button className="px-[2.4rem] py-[1.2rem] text-gray-600 text-[1.6rem] flex items-center justify-center gap-[.4rem] border border-gray-600 rounded-[.5rem]">
           <GrPowerReset />

--- a/src/components/search/FilterBar.tsx
+++ b/src/components/search/FilterBar.tsx
@@ -1,7 +1,7 @@
-import FilterButton from './FilterButton';
-import { TbChartCandle } from 'react-icons/tb';
 import { useState } from 'react';
+import { TbChartCandle } from 'react-icons/tb';
 import BottomSheetFilter from './BottomSheetFilter';
+import FilterButton from './FilterButton';
 
 const filterButtonList = [
   { title: '분야', isBlue: true },
@@ -45,9 +45,15 @@ export default function FilterBar() {
         </button>
       </div>
       {openFilter && (
-        <div className="absolute bottom-0 z-10 w-full">
-          <BottomSheetFilter />
-        </div>
+        <>
+          <div
+            className="fixed inset-0 bg-black bg-opacity-35 z-10"
+            onClick={onClickFilter}
+          ></div>
+          <div className="absolute bottom-0 z-10 w-full ">
+            <BottomSheetFilter onClose={() => setOpenFilter(false)} />
+          </div>
+        </>
       )}
     </>
   );

--- a/src/components/search/TabBarUnderBlue.tsx
+++ b/src/components/search/TabBarUnderBlue.tsx
@@ -14,8 +14,8 @@ export default function TabBarUnderBlue(props: TTabBarBlueProps) {
   const [activeTab, setActiveTab] = useState(tabList[0].name);
 
   return (
-    <>
-      <ul className="w-full px-[1.6rem] flex justify-center items-center text-center border-b-[.1rem] border-gray-200">
+    <div className="flex flex-col h-full">
+      <ul className="w-full px-[1.6rem] flex justify-center items-center text-center border-b-[.1rem] text-gray-700 border-gray-200">
         {tabList.map((tab) => (
           <li
             key={tab.name}
@@ -30,9 +30,9 @@ export default function TabBarUnderBlue(props: TTabBarBlueProps) {
           </li>
         ))}
       </ul>
-      <div className="h-[54vh] w-full p-[1.6rem]">
+      <div className="w-full flex-1 overflow-auto px-[1.8rem] py-[2.4rem]">
         {tabList.find((tab) => tab.name === activeTab)?.component}
       </div>
-    </>
+    </div>
   );
 }

--- a/src/components/search/filter/Period.tsx
+++ b/src/components/search/filter/Period.tsx
@@ -2,7 +2,7 @@ import RangeCalendar from '@/components/common/calender/RangeCalendar';
 
 export default function Period() {
   return (
-    <div className="border p-[4rem]">
+    <div className="border p-[2rem]">
       <RangeCalendar />
     </div>
   );


### PR DESCRIPTION
### 🖼️ Screen shot

| 완성 이미지/GIF |
| :-------------: |
| <img width="384" alt="스크린샷 2024-07-12 오전 11 51 05" src="https://github.com/user-attachments/assets/3c316355-dc8e-45a5-96bc-646bed9dde35">
 />  |

### 📝 Details

- 탭바 영역 고정 후 하위 영역 스크롤 생성으로 변경
- 필터 모달 뒤에 배경색 추가
- 달력 버튼 크기 max-width로 처리

### 💬 Thinking

1. 아이폰 5se 기준으로는 필터 높이가 적당한데 길고 큰 핸드폰 사이즈에서는 필터 부분 높이가 좀 길어보여서 고민입니당
