### PR TITLE
[fix] 매칭배너를통한 로그인유무따라 이동처리 완료

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,9 +7,8 @@ import SearchLabelList from '@/components/main/SearchLabelList';
 import TabBar from '@/components/main/TabBar';
 import UserCardList from '@/components/main/UserCardList';
 import { getSession } from '@/utils/getSessions';
-import Link from 'next/link';
-import { IoIosArrowForward } from 'react-icons/io';
 import SearchPart from './(ryukyung)/pages/SearchPart';
+import { MatchingBanner } from '@/components/common/MatchingBanner';
 
 export default async function page() {
   const session = await getSession();
@@ -27,16 +26,9 @@ export default async function page() {
       <Ismatching session={session} data={data} />
       <TabBar />
       <Banner />
-      <Link href="/matching">
-        <p className="w-full bg-gray-1000 text-gray-100 flex justify-start items-center gap-[0.8rem] px-[1.6rem] py-[1.2rem]">
-          <img src="/small-logo.svg" alt="스터링 미니 로고" />
-          <span className=" text-content-1">
-            매칭 항목 선택하고 딱 맞는 스터디 추천받기
-          </span>
 
-          <IoIosArrowForward />
-        </p>
-      </Link>
+      <MatchingBanner user={user} />
+
       <SearchPart isList={false} />
       <SectionNavigator title="분야별 스터디 탐색하기" moveLink="/search" />
       <SearchLabelList />

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -30,8 +30,6 @@ export default function Header({ user }: { user?: any }) {
     }
   };
 
-  console.log(user.message, '✔');
-
   return (
     <>
       {isOpenMenu && (

--- a/src/components/common/MatchingBanner.tsx
+++ b/src/components/common/MatchingBanner.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import { IoIosArrowForward } from 'react-icons/io';
+import { useRouter } from 'next/navigation';
+
+export function MatchingBanner({ user }: { user: any }) {
+  const router = useRouter();
+  console.log(user === undefined);
+
+  const onClickMathcingBanner = () => {
+    if (user === undefined) {
+      alert('로그인하세요!');
+    } else {
+      router.push('/matching');
+    }
+  };
+  return (
+    <button onClick={onClickMathcingBanner} className="w-full">
+      <p className="w-full bg-gray-1000 text-gray-100 flex justify-start items-center gap-[0.8rem] px-[1.6rem] py-[1.2rem]">
+        <img src="/small-logo.svg" alt="스터링 미니 로고" />
+        <span className=" text-content-1">
+          매칭 항목 선택하고 딱 맞는 스터디 추천받기
+        </span>
+
+        <IoIosArrowForward />
+      </p>
+    </button>
+  );
+}

--- a/src/components/sidebar/SideBar.tsx
+++ b/src/components/sidebar/SideBar.tsx
@@ -9,7 +9,6 @@ type TSideBarProps = {
 };
 export default function SideBar(props: TSideBarProps) {
   const { onClose, user } = props;
-  console.log('✅', user);
 
   return (
     <>


### PR DESCRIPTION

### 📝 Details

- 로그인모달이 헤더에 들어가있어 재사용이어려움
- Alert창으로 대체

### 💬 Thinking

1.
