### PR TITLE
[fix] SearchInput 엔터 누르면 검색가능

### DIFF
--- a/src/components/common/SearchInput.tsx
+++ b/src/components/common/SearchInput.tsx
@@ -21,6 +21,11 @@ export default function SearchInput(props: TSearchInputProps) {
           placeholder={placeholderText}
           value={value}
           onChange={changeHandler}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              localsave();
+            }
+          }}
           className="w-[27rem] inline-block bg-inherit py-[1.3rem] pr-[2rem] text-content-1 placeholder-gray-700"
         />
         <button onClick={localsave}>


### PR DESCRIPTION


### 📝 Details

- SearchInput 컴포넌트 onKeyDown 추가
- 엔터누르면 검색되도록(기존 아이콘 직접클릭)

### 💬 Thinking

1.
