### PR TITLE
[fix] 카드 컴포넌트에서 종료된 스터디 이미지 흑백, 종료처리

### DIFF
--- a/src/components/common/Card.tsx
+++ b/src/components/common/Card.tsx
@@ -64,6 +64,10 @@ export default function Card(props: TStudy) {
   const start = studyStart.split('T')[0].split('-').slice(1).join('.');
   const end = studyEnd.split('T')[0].split('-').slice(1).join('.');
 
+  let isStudyEnd = false;
+  if (new Date(studyEnd).getTime() < new Date().getTime()) {
+    isStudyEnd = true;
+  }
   return (
     <div className="w-full m-auto">
       <div className="relative w-full min-h-[15rem] mb-[1.2rem]">
@@ -71,12 +75,16 @@ export default function Card(props: TStudy) {
           src={studyImage}
           fill={true}
           alt="Card Image"
-          className="rounded-[0.8rem] object-cover"
+          className={`${
+            isStudyEnd
+              ? 'rounded-[0.8rem] object-cover grayscale'
+              : 'rounded-[0.8rem] object-cover'
+          }`}
           sizes="(max-width: 768px) 100vw, (max-width: 1200px) 75vw, 50vw"
           priority
           style={{ minWidth: '163px', minHeight: '150px' }}
         />
-        {userId && (
+        {(userId || !isStudyEnd) && (
           <div
             className="absolute top-0 right-0 m-[0.8rem] p-[0.15rem] text-white"
             onClick={onClickBookmark}
@@ -89,7 +97,7 @@ export default function Card(props: TStudy) {
           </div>
         )}
         <div className="absolute bottom-0 left-0 right-0 rounded-b-[0.8rem] bg-black bg-opacity-80 text-white text-center text-content-2 p-[0.3rem] select-none">
-          {studyMeetings}
+          {isStudyEnd ? '종료' : studyMeetings}
         </div>
       </div>
       <div className="mb-[0.4rem] [&>span]:ml-0 [&>span]:mr-2 select-none">
@@ -143,7 +151,7 @@ export default function Card(props: TStudy) {
       </div>
       <div className="my-2 border-t border-white"></div>
       <p className="text-gray-700 text-content-2">
-        모집 중 {studyJoinMember}/{studyMember}
+        {isStudyEnd ? '종료' : '모집 중'} {studyJoinMember}/{studyMember}
       </p>
     </div>
   );


### PR DESCRIPTION
### 🖼️ Screen shot

| 완성 이미지/GIF |
| :-------------: |
| <img width="190" alt="image" src="https://github.com/user-attachments/assets/93a84a6f-31e8-4eed-85bb-057f71c7e8eb">  |

### 📝 Details
- 이미지 흑백, 종료문구 추가

### 💬 Thinking
- 카드 컴포넌트 클릭시, 해당 스터디 상세페이지로 넘어가는데 이때 처리 어떻게 할건지(아예 접속을 막을건지? 아니면 이미지 흑백처리 해놓고 종료된 스터디임을 보여줄지)
