### PR TITLE
[fix] 스터디 상세페이지 스터디 이미지 어둡게 처리, 스터디상세/강의 상세 뒤로가기,공유 아이콘 색상 조건부변경

### DIFF
--- a/src/app/(jisubin)/_components/BackShareHeader.tsx
+++ b/src/app/(jisubin)/_components/BackShareHeader.tsx
@@ -4,7 +4,11 @@ import Toast from '@/components/common/Toast';
 import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
 
-export default function BackShareHeader() {
+type TBackShareHeaderProps = {
+  iconColor: string;
+};
+export default function BackShareHeader(props: TBackShareHeaderProps) {
+  const { iconColor } = props;
   const [isToastShow, setIsToastShow] = useState(false);
   const router = useRouter();
 
@@ -41,7 +45,7 @@ export default function BackShareHeader() {
           >
             <path
               d="M15 19L8 11.5L15 4"
-              stroke="#010101"
+              stroke={iconColor}
               strokeWidth="1.7"
               strokeLinecap="round"
             />
@@ -58,22 +62,14 @@ export default function BackShareHeader() {
             <g clipPath="url(#clip0_1093_10946)">
               <path
                 d="M16.5 9.75H18.75C18.9489 9.75 19.1397 9.82902 19.2803 9.96967C19.421 10.1103 19.5 10.3011 19.5 10.5V19.5C19.5 19.6989 19.421 19.8897 19.2803 20.0303C19.1397 20.171 18.9489 20.25 18.75 20.25H5.25C5.05109 20.25 4.86032 20.171 4.71967 20.0303C4.57902 19.8897 4.5 19.6989 4.5 19.5V10.5C4.5 10.3011 4.57902 10.1103 4.71967 9.96967C4.86032 9.82902 5.05109 9.75 5.25 9.75H7.5"
-                stroke="#313131"
+                stroke={iconColor}
                 strokeWidth="1.5"
                 strokeLinecap="round"
                 strokeLinejoin="round"
               />
               <path
                 d="M16.5 9.75H18.75C18.9489 9.75 19.1397 9.82902 19.2803 9.96967C19.421 10.1103 19.5 10.3011 19.5 10.5V19.5C19.5 19.6989 19.421 19.8897 19.2803 20.0303C19.1397 20.171 18.9489 20.25 18.75 20.25H5.25C5.05109 20.25 4.86032 20.171 4.71967 20.0303C4.57902 19.8897 4.5 19.6989 4.5 19.5V10.5C4.5 10.3011 4.57902 10.1103 4.71967 9.96967C4.86032 9.82902 5.05109 9.75 5.25 9.75H7.5"
-                stroke="black"
-                strokeOpacity="0.2"
-                strokeWidth="1.5"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              />
-              <path
-                d="M16.5 9.75H18.75C18.9489 9.75 19.1397 9.82902 19.2803 9.96967C19.421 10.1103 19.5 10.3011 19.5 10.5V19.5C19.5 19.6989 19.421 19.8897 19.2803 20.0303C19.1397 20.171 18.9489 20.25 18.75 20.25H5.25C5.05109 20.25 4.86032 20.171 4.71967 20.0303C4.57902 19.8897 4.5 19.6989 4.5 19.5V10.5C4.5 10.3011 4.57902 10.1103 4.71967 9.96967C4.86032 9.82902 5.05109 9.75 5.25 9.75H7.5"
-                stroke="black"
+                stroke={iconColor}
                 strokeOpacity="0.2"
                 strokeWidth="1.5"
                 strokeLinecap="round"
@@ -81,7 +77,7 @@ export default function BackShareHeader() {
               />
               <path
                 d="M16.5 9.75H18.75C18.9489 9.75 19.1397 9.82902 19.2803 9.96967C19.421 10.1103 19.5 10.3011 19.5 10.5V19.5C19.5 19.6989 19.421 19.8897 19.2803 20.0303C19.1397 20.171 18.9489 20.25 18.75 20.25H5.25C5.05109 20.25 4.86032 20.171 4.71967 20.0303C4.57902 19.8897 4.5 19.6989 4.5 19.5V10.5C4.5 10.3011 4.57902 10.1103 4.71967 9.96967C4.86032 9.82902 5.05109 9.75 5.25 9.75H7.5"
-                stroke="black"
+                stroke={iconColor}
                 strokeOpacity="0.2"
                 strokeWidth="1.5"
                 strokeLinecap="round"
@@ -89,7 +85,7 @@ export default function BackShareHeader() {
               />
               <path
                 d="M16.5 9.75H18.75C18.9489 9.75 19.1397 9.82902 19.2803 9.96967C19.421 10.1103 19.5 10.3011 19.5 10.5V19.5C19.5 19.6989 19.421 19.8897 19.2803 20.0303C19.1397 20.171 18.9489 20.25 18.75 20.25H5.25C5.05109 20.25 4.86032 20.171 4.71967 20.0303C4.57902 19.8897 4.5 19.6989 4.5 19.5V10.5C4.5 10.3011 4.57902 10.1103 4.71967 9.96967C4.86032 9.82902 5.05109 9.75 5.25 9.75H7.5"
-                stroke="black"
+                stroke={iconColor}
                 strokeOpacity="0.2"
                 strokeWidth="1.5"
                 strokeLinecap="round"
@@ -97,7 +93,7 @@ export default function BackShareHeader() {
               />
               <path
                 d="M16.5 9.75H18.75C18.9489 9.75 19.1397 9.82902 19.2803 9.96967C19.421 10.1103 19.5 10.3011 19.5 10.5V19.5C19.5 19.6989 19.421 19.8897 19.2803 20.0303C19.1397 20.171 18.9489 20.25 18.75 20.25H5.25C5.05109 20.25 4.86032 20.171 4.71967 20.0303C4.57902 19.8897 4.5 19.6989 4.5 19.5V10.5C4.5 10.3011 4.57902 10.1103 4.71967 9.96967C4.86032 9.82902 5.05109 9.75 5.25 9.75H7.5"
-                stroke="black"
+                stroke={iconColor}
                 strokeOpacity="0.2"
                 strokeWidth="1.5"
                 strokeLinecap="round"
@@ -105,7 +101,7 @@ export default function BackShareHeader() {
               />
               <path
                 d="M16.5 9.75H18.75C18.9489 9.75 19.1397 9.82902 19.2803 9.96967C19.421 10.1103 19.5 10.3011 19.5 10.5V19.5C19.5 19.6989 19.421 19.8897 19.2803 20.0303C19.1397 20.171 18.9489 20.25 18.75 20.25H5.25C5.05109 20.25 4.86032 20.171 4.71967 20.0303C4.57902 19.8897 4.5 19.6989 4.5 19.5V10.5C4.5 10.3011 4.57902 10.1103 4.71967 9.96967C4.86032 9.82902 5.05109 9.75 5.25 9.75H7.5"
-                stroke="black"
+                stroke={iconColor}
                 strokeOpacity="0.2"
                 strokeWidth="1.5"
                 strokeLinecap="round"
@@ -113,7 +109,15 @@ export default function BackShareHeader() {
               />
               <path
                 d="M16.5 9.75H18.75C18.9489 9.75 19.1397 9.82902 19.2803 9.96967C19.421 10.1103 19.5 10.3011 19.5 10.5V19.5C19.5 19.6989 19.421 19.8897 19.2803 20.0303C19.1397 20.171 18.9489 20.25 18.75 20.25H5.25C5.05109 20.25 4.86032 20.171 4.71967 20.0303C4.57902 19.8897 4.5 19.6989 4.5 19.5V10.5C4.5 10.3011 4.57902 10.1103 4.71967 9.96967C4.86032 9.82902 5.05109 9.75 5.25 9.75H7.5"
-                stroke="black"
+                stroke={iconColor}
+                strokeOpacity="0.2"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+              <path
+                d="M16.5 9.75H18.75C18.9489 9.75 19.1397 9.82902 19.2803 9.96967C19.421 10.1103 19.5 10.3011 19.5 10.5V19.5C19.5 19.6989 19.421 19.8897 19.2803 20.0303C19.1397 20.171 18.9489 20.25 18.75 20.25H5.25C5.05109 20.25 4.86032 20.171 4.71967 20.0303C4.57902 19.8897 4.5 19.6989 4.5 19.5V10.5C4.5 10.3011 4.57902 10.1103 4.71967 9.96967C4.86032 9.82902 5.05109 9.75 5.25 9.75H7.5"
+                stroke={iconColor}
                 strokeOpacity="0.2"
                 strokeWidth="1.5"
                 strokeLinecap="round"
@@ -121,22 +125,14 @@ export default function BackShareHeader() {
               />
               <path
                 d="M8.25 6L12 2.25L15.75 6"
-                stroke="#313131"
+                stroke={iconColor}
                 strokeWidth="1.5"
                 strokeLinecap="round"
                 strokeLinejoin="round"
               />
               <path
                 d="M8.25 6L12 2.25L15.75 6"
-                stroke="black"
-                strokeOpacity="0.2"
-                strokeWidth="1.5"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              />
-              <path
-                d="M8.25 6L12 2.25L15.75 6"
-                stroke="black"
+                stroke={iconColor}
                 strokeOpacity="0.2"
                 strokeWidth="1.5"
                 strokeLinecap="round"
@@ -144,7 +140,7 @@ export default function BackShareHeader() {
               />
               <path
                 d="M8.25 6L12 2.25L15.75 6"
-                stroke="black"
+                stroke={iconColor}
                 strokeOpacity="0.2"
                 strokeWidth="1.5"
                 strokeLinecap="round"
@@ -152,7 +148,7 @@ export default function BackShareHeader() {
               />
               <path
                 d="M8.25 6L12 2.25L15.75 6"
-                stroke="black"
+                stroke={iconColor}
                 strokeOpacity="0.2"
                 strokeWidth="1.5"
                 strokeLinecap="round"
@@ -160,7 +156,7 @@ export default function BackShareHeader() {
               />
               <path
                 d="M8.25 6L12 2.25L15.75 6"
-                stroke="black"
+                stroke={iconColor}
                 strokeOpacity="0.2"
                 strokeWidth="1.5"
                 strokeLinecap="round"
@@ -168,7 +164,7 @@ export default function BackShareHeader() {
               />
               <path
                 d="M8.25 6L12 2.25L15.75 6"
-                stroke="black"
+                stroke={iconColor}
                 strokeOpacity="0.2"
                 strokeWidth="1.5"
                 strokeLinecap="round"
@@ -176,7 +172,15 @@ export default function BackShareHeader() {
               />
               <path
                 d="M8.25 6L12 2.25L15.75 6"
-                stroke="black"
+                stroke={iconColor}
+                strokeOpacity="0.2"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+              <path
+                d="M8.25 6L12 2.25L15.75 6"
+                stroke="#fff"
                 strokeOpacity="0.2"
                 strokeWidth="1.5"
                 strokeLinecap="round"
@@ -184,14 +188,14 @@ export default function BackShareHeader() {
               />
               <path
                 d="M12 2.25V12.75"
-                stroke="#313131"
+                stroke={iconColor}
                 strokeWidth="1.5"
                 strokeLinecap="round"
                 strokeLinejoin="round"
               />
               <path
                 d="M12 2.25V12.75"
-                stroke="black"
+                stroke={iconColor}
                 strokeOpacity="0.2"
                 strokeWidth="1.5"
                 strokeLinecap="round"
@@ -199,7 +203,7 @@ export default function BackShareHeader() {
               />
               <path
                 d="M12 2.25V12.75"
-                stroke="black"
+                stroke={iconColor}
                 strokeOpacity="0.2"
                 strokeWidth="1.5"
                 strokeLinecap="round"
@@ -207,7 +211,7 @@ export default function BackShareHeader() {
               />
               <path
                 d="M12 2.25V12.75"
-                stroke="black"
+                stroke={iconColor}
                 strokeOpacity="0.2"
                 strokeWidth="1.5"
                 strokeLinecap="round"
@@ -215,7 +219,7 @@ export default function BackShareHeader() {
               />
               <path
                 d="M12 2.25V12.75"
-                stroke="black"
+                stroke={iconColor}
                 strokeOpacity="0.2"
                 strokeWidth="1.5"
                 strokeLinecap="round"
@@ -223,7 +227,7 @@ export default function BackShareHeader() {
               />
               <path
                 d="M12 2.25V12.75"
-                stroke="black"
+                stroke={iconColor}
                 strokeOpacity="0.2"
                 strokeWidth="1.5"
                 strokeLinecap="round"
@@ -231,7 +235,7 @@ export default function BackShareHeader() {
               />
               <path
                 d="M12 2.25V12.75"
-                stroke="black"
+                stroke={iconColor}
                 strokeOpacity="0.2"
                 strokeWidth="1.5"
                 strokeLinecap="round"
@@ -239,7 +243,7 @@ export default function BackShareHeader() {
               />
               <path
                 d="M12 2.25V12.75"
-                stroke="black"
+                stroke={iconColor}
                 strokeOpacity="0.2"
                 strokeWidth="1.5"
                 strokeLinecap="round"
@@ -248,7 +252,7 @@ export default function BackShareHeader() {
             </g>
             <defs>
               <clipPath id="clip0_1093_10946">
-                <rect width="24" height="24" fill="white" />
+                <rect width="24" height="24" fill={iconColor} />
               </clipPath>
             </defs>
           </svg>

--- a/src/app/(jisubin)/lecture-detail/[id]/layout.tsx
+++ b/src/app/(jisubin)/lecture-detail/[id]/layout.tsx
@@ -35,7 +35,7 @@ export default async function LectureDetailLayout(
   return (
     <>
       <div className="bg-gradient-to-tr from-[#D9E3FF] to-[#FFE4E0] ">
-        <BackShareHeader />
+        <BackShareHeader iconColor="black" />
         <LectureStudyTitle
           rating={lecture.lectureRating}
           title={lecture.lectureName}

--- a/src/app/(jisubin)/study-detail/[id]/layout.tsx
+++ b/src/app/(jisubin)/study-detail/[id]/layout.tsx
@@ -63,14 +63,14 @@ export default async function StudyDetailLayout(
     <>
       <div
         style={{
-          backgroundImage: `url(${study.studyImage})`,
+          backgroundImage: `linear-gradient( rgba(0, 0, 0, 0.3), rgba(0, 0, 0, 0.5) ), url(${study.studyImage})`,
           backgroundSize: 'cover',
           backgroundRepeat: 'no-repeat',
           backgroundPosition: 'center',
         }}
         className={`text-white object-cover`}
       >
-        <BackShareHeader />
+        <BackShareHeader iconColor="white" />
         <StudyDetailTitle
           type={study.studyType}
           category={study.studyCategory}


### PR DESCRIPTION
### 📝 Details

- PR 제목과 동일합니다.
- 상세페이지 하단 스터디 이미지 어둡게처리, 뒤로가기, 공유아이콘 색상 조건부변경

### 💬 Thinking

1.
