### PR TITLE
[design] 스크롤 히든으로 처리 / [fix] 매칭정보 없을 경우에 인기순, 최신순으로 문구 변경

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "react-dom": "^18",
         "react-icons": "^5.2.1",
         "swiper": "^11.1.4",
+        "tailwind-scrollbar-hide": "^1.1.7",
         "zustand": "^4.5.4"
       },
       "devDependencies": {
@@ -5136,6 +5137,11 @@
       "engines": {
         "node": ">= 4.7.0"
       }
+    },
+    "node_modules/tailwind-scrollbar-hide": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/tailwind-scrollbar-hide/-/tailwind-scrollbar-hide-1.1.7.tgz",
+      "integrity": "sha512-X324n9OtpTmOMqEgDUEA/RgLrNfBF/jwJdctaPZDzB3mppxJk7TLIDmOreEDm1Bq4R9LSPu4Epf8VSdovNU+iA=="
     },
     "node_modules/tailwindcss": {
       "version": "3.4.4",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "react-dom": "^18",
     "react-icons": "^5.2.1",
     "swiper": "^11.1.4",
+    "tailwind-scrollbar-hide": "^1.1.7",
     "zustand": "^4.5.4"
   },
   "devDependencies": {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,6 @@
 import CreateStudyButton from '@/components/common/CreateStudyButton';
 import Footer from '@/components/common/Footer';
+import Ismatching from '@/components/common/Ismatching';
 import { MatchingBanner } from '@/components/common/MatchingBanner';
 import SectionNavigator from '@/components/common/SectionNavigator';
 import Banner from '@/components/main/Banner';
@@ -9,7 +10,6 @@ import UserCardList from '@/components/main/UserCardList';
 import { getSession } from '@/utils/getSessions';
 import dynamic from 'next/dynamic';
 import SearchPart from './search/_components/SearchPart';
-import Ismatching from '@/components/common/Ismatching';
 const StudyCardList = dynamic(
   () => import('@/components/common/StudyCardList'),
 );
@@ -24,6 +24,9 @@ export default async function page() {
       cache: 'no-store',
     })
   ).json();
+
+  const isLoggedIn = !!session;
+  const isMatched = data && data.matchinginfo !== null;
 
   return (
     <>
@@ -41,7 +44,7 @@ export default async function page() {
       <SectionNavigator title="분야별 스터디 탐색하기" moveLink="/search" />
       <SearchLabelList />
       <hr className="w-full block h-[0.8rem] bg-gray-100 border-0 my-[4rem]" />
-      {!session ? (
+      {!isLoggedIn || (isLoggedIn && !isMatched) ? (
         <>
           <SectionNavigator title="이번주 인기 스터디" moveLink="/search" />
           <StudyCardList sort={'popular'} />

--- a/src/components/common/Card.tsx
+++ b/src/components/common/Card.tsx
@@ -96,7 +96,7 @@ export default function Card(props: TStudy) {
             )}
           </button>
         )}
-        <div className="absolute bottom-0 left-0 right-0 rounded-b-[0.8rem] bg-black bg-opacity-80 text-white text-center text-content-2 p-[0.3rem] select-none">
+        <div className="w-full absolute bottom-0 left-0 right-0 rounded-b-[0.8rem] bg-black bg-opacity-80 text-white text-center text-content-2 p-[0.3rem] select-none">
           {isStudyEnd ? '종료' : studyMeetings}
         </div>
       </div>

--- a/src/components/common/ScrollableContainer.tsx
+++ b/src/components/common/ScrollableContainer.tsx
@@ -5,6 +5,8 @@ type TScrollableContainer = {
 export default function ScrollableContainer(props: TScrollableContainer) {
   const { children } = props;
   return (
-    <ul className="w-full overflow-y-auto flex gap-[.8rem]">{children}</ul>
+    <ul className="w-full overflow-y-auto scrollbar-hide flex gap-[.8rem]">
+      {children}
+    </ul>
   );
 }

--- a/src/components/common/SearchInput.tsx
+++ b/src/components/common/SearchInput.tsx
@@ -26,7 +26,7 @@ export default function SearchInput(props: TSearchInputProps) {
               localsave();
             }
           }}
-          className="w-full inline-block bg-inherit py-[1.3rem] pr-[2rem] text-content-1 placeholder-gray-700 focus:outline-none"
+          className="w-full inline-block bg-transparent py-[1.3rem] pr-[2rem] text-content-1 placeholder-gray-700 focus:outline-none"
         />
         <button onClick={localsave}>
           <IoSearch className="w-[2.4rem] h-[2.4rem] text-main-600" />

--- a/src/components/search/FilterBar.tsx
+++ b/src/components/search/FilterBar.tsx
@@ -58,7 +58,7 @@ export default function FilterBar({
   return (
     <>
       <div className=" w-full px-[1.6rem] py-[.8rem] flex justify-between items-center">
-        <ul className="flex w-[90%] overflow-x-auto py-[1.2rem]">
+        <ul className="flex w-[90%] overflow-x-auto py-[1.2rem] scrollbar-hide">
           {filterButtonList &&
             filterButtonList.map((filterbutton) => (
               <li key={filterbutton.key} className="inline mr-[.8rem]">

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -76,7 +76,7 @@ const config: Config = {
       '2': '2rem',
     },
   },
-  plugins: [],
+  plugins: [require('tailwind-scrollbar-hide')],
 };
 
 export default config;


### PR DESCRIPTION
### 🖼️ Screen shot

| 수정 전 | 수정 후 |
| :-------------: | :--------:|
| <img width="374" alt="스크린샷 2024-08-02 오전 1 54 39" src="https://github.com/user-attachments/assets/e253f9fd-a946-425c-86f5-462d339c084d"> | <img width="364" alt="스크린샷 2024-08-02 오전 1 51 32" src="https://github.com/user-attachments/assets/d96e8388-d758-4b13-9f93-84de5daf65ca">


### 📝 Details

- npm intsall tailwind-scrollbar-hide로 스크롤 히든으로 처리 했습니다!
- 로그인 후 매칭정보 없을 경우 인기순, 최신순으로 변경 했습니다.


